### PR TITLE
Initial setting of state (null/ready/paused/playing) for each input/output/mixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ There are three ways to configure Brave:
 
 1. Web interface
 2. REST API (plus optoinal websocket)
-3. Config file
+3. [Config file](./docs/config_file.md)
 
 
 #### Web interface
@@ -158,16 +158,16 @@ The API allows read/write access of the state of Brave, including being able to 
 
 
 #### Config file
-Configuring inputs/outputs/overlays using the config file allows them to be set up straightaway when Brave starts.
-However, the config file is not read again after the start, so it cannot be used to dynamically change things (e.g. add a new input).
-
-The default config file can be found at `config/default.yaml`.
+Brave can be configured by config file.
+This includes being able to have certain inputs, mixers, outputs and overlays created when Brave starts.
 
 Provide another config with the `-c` parameter, e.g.
 
 ```
 ./brave.py -c config/example_empty.yaml
 ```
+
+See the [Config File](./docs/config_file.md) documentation for more.
 
 ## Tests
 Brave has functional black-box tests that ensure the config file and API is working correctly.

--- a/brave/inputs/html.py
+++ b/brave/inputs/html.py
@@ -1,5 +1,4 @@
 from brave.inputs.input import Input
-from gi.repository import Gst
 import brave.config as config
 
 
@@ -14,6 +13,7 @@ class HTMLInput(Input):
 
     def permitted_props(self):
         return {
+            **super().permitted_props(),
             'uri': {
                 'type': 'str',
                 'defatult': 'https://www.bbc.co.uk'
@@ -55,7 +55,6 @@ class HTMLInput(Input):
 
         self.create_intervideosrc_and_connections()
         self.handle_updated_props()
-        self.pipeline.set_state(Gst.State.PLAYING)
 
     def get_input_cap_props(self):
         '''

--- a/brave/inputs/image.py
+++ b/brave/inputs/image.py
@@ -1,5 +1,4 @@
 from brave.inputs.input import Input
-from gi.repository import Gst
 import brave.config as config
 
 
@@ -14,6 +13,7 @@ class ImageInput(Input):
 
     def permitted_props(self):
         return {
+            **super().permitted_props(),
             'uri': {
                 'type': 'str',
             },
@@ -54,7 +54,6 @@ class ImageInput(Input):
 
         self.create_intervideosrc_and_connections()
         self.handle_updated_props()
-        self.pipeline.set_state(Gst.State.PLAYING)
 
     def get_input_cap_props(self):
         '''

--- a/brave/inputs/input.py
+++ b/brave/inputs/input.py
@@ -13,6 +13,9 @@ class Input(InputOutputOverlay):
         self.session().mixers[0].sources.add(self)
         self.create_elements()
 
+        # Set initially to READY, and when there we set to self.props['initial_state']
+        self.pipeline.set_state(Gst.State.READY)
+
     def input_output_overlay_or_mixer(self):
         return 'input'
 

--- a/brave/inputs/test_audio.py
+++ b/brave/inputs/test_audio.py
@@ -1,5 +1,4 @@
 from brave.inputs.input import Input
-from gi.repository import Gst
 import brave.config as config
 
 
@@ -9,6 +8,7 @@ class TestAudioInput(Input):
 
     def permitted_props(self):
         return {
+            **super().permitted_props(),
             'freq': {
                 'type': 'int',
                 'default': 440
@@ -34,7 +34,6 @@ class TestAudioInput(Input):
         self.audiotestsrc = self.pipeline.get_by_name('audiotestsrc')
         self.create_interaudiosrc_and_connections()
         self.handle_updated_props()
-        self.pipeline.set_state(Gst.State.PLAYING)
 
     def handle_updated_props(self):
         super().handle_updated_props()

--- a/brave/inputs/test_video.py
+++ b/brave/inputs/test_video.py
@@ -1,5 +1,4 @@
 from brave.inputs.input import Input
-from gi.repository import Gst
 
 
 class TestVideoInput(Input):
@@ -8,6 +7,7 @@ class TestVideoInput(Input):
 
     def permitted_props(self):
         return {
+            **super().permitted_props(),
             'pattern': {
                 'type': 'int',
                 'default': 0
@@ -49,7 +49,6 @@ class TestVideoInput(Input):
 
         self.create_intervideosrc_and_connections()
         self.handle_updated_props()
-        self.set_state(Gst.State.PLAYING)
 
     def handle_updated_props(self):
         super().handle_updated_props()

--- a/brave/inputs/uri.py
+++ b/brave/inputs/uri.py
@@ -11,6 +11,7 @@ class UriInput(Input):
 
     def permitted_props(self):
         return {
+            **super().permitted_props(),
             'uri': {
                 'type': 'str',
             },
@@ -57,7 +58,6 @@ class UriInput(Input):
             self._create_fake_audio()
 
         self.handle_updated_props()
-        self.set_state(Gst.State.PLAYING)
 
     def _create_fake_video(self):
         fakesink = Gst.ElementFactory.make('fakesink')

--- a/brave/mixers/mixer.py
+++ b/brave/mixers/mixer.py
@@ -15,9 +15,14 @@ class Mixer(InputOutputOverlay):
         args['type'] = 'mixer'
         super().__init__(**args)
         self.sources = SourceCollection(self)
+        self.create_elements()
+
+        # Set initially to READY, and when there we set to self.props['initial_state']
+        self.set_state(Gst.State.READY)
 
     def permitted_props(self):
         return {
+            **super().permitted_props(),
             'width': {
                 'type': 'int',
                 'default': config.default_mixer_width()

--- a/brave/outputs/file.py
+++ b/brave/outputs/file.py
@@ -64,7 +64,6 @@ class FileOutput(Output):
             self.interaudiosrc_src_pad = self.interaudiosrc.get_static_pad('src')
             self.create_interaudiosink_and_connections()
 
-        self.pipeline.set_state(Gst.State.PLAYING)
         self._sync_elements_on_source_pipeline()
 
     def set_state(self, new_state):

--- a/brave/outputs/file.py
+++ b/brave/outputs/file.py
@@ -64,8 +64,6 @@ class FileOutput(Output):
             self.interaudiosrc_src_pad = self.interaudiosrc.get_static_pad('src')
             self.create_interaudiosink_and_connections()
 
-        self._sync_elements_on_source_pipeline()
-
     def set_state(self, new_state):
         sent_eos = False
         # If this is ending the file creation (identified by moving to READY or NULL)

--- a/brave/outputs/image.py
+++ b/brave/outputs/image.py
@@ -1,5 +1,4 @@
 from brave.outputs.output import Output
-from gi.repository import Gst
 import brave.config as config
 import os
 
@@ -53,7 +52,6 @@ class ImageOutput(Output):
         sink.set_property('location', self.props['location'])
 
         self.create_intervideosink_and_connections()
-        self.pipeline.set_state(Gst.State.PLAYING)
         self._sync_elements_on_source_pipeline()
 
     def __delete_file_if_exists(self):

--- a/brave/outputs/image.py
+++ b/brave/outputs/image.py
@@ -52,7 +52,6 @@ class ImageOutput(Output):
         sink.set_property('location', self.props['location'])
 
         self.create_intervideosink_and_connections()
-        self._sync_elements_on_source_pipeline()
 
     def __delete_file_if_exists(self):
         try:

--- a/brave/outputs/local.py
+++ b/brave/outputs/local.py
@@ -1,5 +1,4 @@
 from brave.outputs.output import Output
-from gi.repository import Gst
 import brave.config as config
 import brave.exceptions
 
@@ -56,8 +55,5 @@ class LocalOutput(Output):
             self.interaudiosrc = self.pipeline.get_by_name('interaudiosrc')
             self.interaudiosrc_src_pad = self.interaudiosrc.get_static_pad('src')
             self.create_interaudiosink_and_connections()
-
-        if not self.set_state(Gst.State.PLAYING):
-            self.logger.warn('Unable to enter PLAYING state')
 
         self._sync_elements_on_source_pipeline()

--- a/brave/outputs/local.py
+++ b/brave/outputs/local.py
@@ -55,5 +55,3 @@ class LocalOutput(Output):
             self.interaudiosrc = self.pipeline.get_by_name('interaudiosrc')
             self.interaudiosrc_src_pad = self.interaudiosrc.get_static_pad('src')
             self.create_interaudiosink_and_connections()
-
-        self._sync_elements_on_source_pipeline()

--- a/brave/outputs/output.py
+++ b/brave/outputs/output.py
@@ -19,11 +19,15 @@ class Output(InputOutputOverlay):
         # This stores the pads on the source's tee which are connected to this output:
         self.tee_src_pads = {}
 
+        # Set initially to READY, and when there we set to self.props['initial_state']
+        self.pipeline.set_state(Gst.State.READY)
+
     def input_output_overlay_or_mixer(self):
         return 'output'
 
     def permitted_props(self):
         return {
+            **super().permitted_props(),
             'mixer_id': {
                 'type': 'int',
                 'default': 0

--- a/brave/outputs/output.py
+++ b/brave/outputs/output.py
@@ -15,6 +15,7 @@ class Output(InputOutputOverlay):
         self.source = self.session().mixers[self.props['mixer_id']]
 
         self.create_elements()
+        self._sync_elements_on_source_pipeline()
 
         # This stores the pads on the source's tee which are connected to this output:
         self.tee_src_pads = {}

--- a/brave/outputs/rtmp.py
+++ b/brave/outputs/rtmp.py
@@ -74,6 +74,4 @@ class RTMPOutput(Output):
         elif change_to_paused_state_response != Gst.StateChangeReturn.SUCCESS:
             self.logger.warn('Unable to change into PAUSED state:' + str(change_to_paused_state_response))
 
-        self._sync_elements_on_source_pipeline()
-
         self.logger.info('RTMP output now configured to send to ' + self.props['uri'])

--- a/brave/outputs/rtmp.py
+++ b/brave/outputs/rtmp.py
@@ -63,15 +63,4 @@ class RTMPOutput(Output):
             self.interaudiosrc_src_pad = self.interaudiosrc.get_static_pad('src')
             self.create_interaudiosink_and_connections()
 
-        # We set to PAUSED rather than PLAYING because the audio encode needs a moment in preroll.
-        # Without this, a not-negotiated error will occur.
-        # For now, we leave it up to the user to put it into the PLAYING state.
-        # A better solution would be to listen out for the successful prep of the pipeline
-        # and then move into PLAYING.
-        change_to_paused_state_response = self.pipeline.set_state(Gst.State.PAUSED)
-        if change_to_paused_state_response == Gst.StateChangeReturn.NO_PREROLL:
-            self.logger.debug('Moved to PAUSED state but preroll preparation still underway')
-        elif change_to_paused_state_response != Gst.StateChangeReturn.SUCCESS:
-            self.logger.warn('Unable to change into PAUSED state:' + str(change_to_paused_state_response))
-
         self.logger.info('RTMP output now configured to send to ' + self.props['uri'])

--- a/brave/outputs/tcp.py
+++ b/brave/outputs/tcp.py
@@ -1,6 +1,5 @@
 from brave.outputs.output import Output
 import socket
-from gi.repository import Gst
 import brave.config as config
 
 
@@ -110,10 +109,8 @@ class TCPOutput(Output):
         sink.set_property('recover-policy', 'keyframe')
         sink.set_property('sync', False)
 
-        self.pipeline.set_state(Gst.State.PLAYING)
         self._sync_elements_on_source_pipeline()
-        self.logger.info('Now available as TCP... point your VLC at tcp://' +
-                         self.props['host'] + ':' + str(self.props['port']))
+        self.logger.info('TCP output created at tcp://%s:%s' % (self.props['host'], self.props['port']))
 
     def _get_next_available_port(self):
         ports_in_use = self.get_ports_in_use()

--- a/brave/outputs/tcp.py
+++ b/brave/outputs/tcp.py
@@ -109,7 +109,6 @@ class TCPOutput(Output):
         sink.set_property('recover-policy', 'keyframe')
         sink.set_property('sync', False)
 
-        self._sync_elements_on_source_pipeline()
         self.logger.info('TCP output created at tcp://%s:%s' % (self.props['host'], self.props['port']))
 
     def _get_next_available_port(self):

--- a/brave/outputs/webrtc.py
+++ b/brave/outputs/webrtc.py
@@ -52,10 +52,6 @@ class WebRTCOutput(Output):
         self.webrtc_video_tee = self.pipeline.get_by_name('webrtc_video_tee')
         self.webrtc_audio_tee = self.pipeline.get_by_name('webrtc_audio_tee')
 
-        if not self.set_state(Gst.State.READY):
-            self.logger.warn('Unable to enter READY state')
-            return False
-
         self._sync_elements_on_source_pipeline()
         return True
 

--- a/brave/outputs/webrtc.py
+++ b/brave/outputs/webrtc.py
@@ -52,7 +52,6 @@ class WebRTCOutput(Output):
         self.webrtc_video_tee = self.pipeline.get_by_name('webrtc_video_tee')
         self.webrtc_audio_tee = self.pipeline.get_by_name('webrtc_audio_tee')
 
-        self._sync_elements_on_source_pipeline()
         return True
 
     def _create_pipeline(self):

--- a/brave/pipeline_messaging.py
+++ b/brave/pipeline_messaging.py
@@ -62,7 +62,7 @@ def setup_messaging(pipe, parent_object):
             pass
             # logger.debug(f'Message from GStreamer: Async done')
         elif t == Gst.MessageType.STREAM_START:
-            logger.debug(f'Message from GStreamer: Stream has now started.')
+            logger.debug('Message from GStreamer: Stream has now started.')
             if hasattr(parent_object, 'on_pipeline_start'):
                 parent_object.on_pipeline_start()
         elif t == Gst.MessageType.NEW_CLOCK:

--- a/brave/session.py
+++ b/brave/session.py
@@ -59,8 +59,7 @@ class Session(object):
         Create the inputs/outputs/mixers/overlays declared in the config file.
         '''
         for mixer_config in config.default_mixers():
-            mixer = self.mixers.add(**mixer_config)
-            mixer.create_elements()
+            self.mixers.add(**mixer_config)
 
         for output_config in config.default_outputs():
             output = self.outputs.add(**output_config)
@@ -76,9 +75,6 @@ class Session(object):
             input = self.inputs.add(**input_config)
             for source in input.sources():
                 source.add_to_mix()
-
-        for name, mixer in self.mixers.items():
-            mixer.set_state(Gst.State.PLAYING)
 
     def print_state_summary(self):
         '''

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -1,0 +1,140 @@
+# Brave config file
+[Brave](../README.md) can be configured by config file.
+This includes being able to set inputs, mixers, outputs and overlays that are created when Brave starts. It is an alternative to configuring Brave via the API.
+
+Brave does not reconsider the config file after it has started. To configure Brave after it has started (e.g. to add another input), use the API.
+
+## Selecting a config file
+Provide Brave with the config file at startup with the `-c` parameter, e.g.
+
+```
+./brave.py -c config/example_empty.yaml
+```
+
+## Default config file
+The default config file can be found at `config/default.yaml`.
+
+It creates one mixer, and no inputs or outputs.
+
+## Custom config files
+Config files are written in [YAML](http://yaml.org/), and are simple to create by hand.
+
+The following options can be included in the config file.
+
+### `default_inputs`
+Use the `default_inputs` entry to provide an array of inputs that should be created when Brave starts.
+
+Example:
+
+```
+default_inputs:
+     - type: uri
+       props:
+           initial_state: PAUSED
+           uri: rtmp://184.72.239.149/vod/BigBuckBunny_115k.mov
+     - type: image
+       props:
+           zorder: 2
+           uri: file:///home/user/images/image.jpg
+```
+
+Each input must have a type (either `uri`, `image`, `html`, `test_video`, or `test_audio`)
+
+Each input can then, optionally, have `props` containing key-values pairs of the properties of that input. Available properties vary per input. Common ones include:
+
+* `uri` - of the content to display. (Does not exist for `test_video` or `test_audio`)
+* `zorder` - the ordering that that input should appear when mixed
+* `intial_state` - the state that the input should enter. Permitted values: 'PLAYING', 'PAUSED', 'READY', 'NULL. Defaults to PLAYING.
+
+
+### `default_mixers`
+Use the `default_mixers` entry to provide an array of inputs that should be created when Brave starts. If omitted, one mixer will automatically be created.
+
+
+Example:
+
+```
+default_mixers:
+    - props:
+        width: 640
+        height: 360
+        pattern: 6	
+```
+
+Unlike inputs and outputs, mixers do not have a type.
+
+Properties, all optional, are:
+
+* `width` - if not set, defaults to `default_mixer_height` (see below)
+* `height` - if not set, defaults to `default_mixer_width` (see below)
+* `pattern` - bettween 0 and 24, matching the pattern list [here](https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-base-plugins/html/gst-plugins-base-plugins-videotestsrc.html#GstVideoTestSrcPattern.members). If not set, defaults to 0 (SMPTE test pattern)
+* `intial_state` - the state that the mixer should enter. Permitted values: 'PLAYING', 'PAUSED', 'READY', 'NULL. Defaults to PLAYING.
+
+### `default_outputs`
+`default_outputs` is an array array of inputs that should be created when Brave starts.
+
+Example (creating four outputs of different types):
+
+```
+default_outputs:
+    - type: local
+      props:
+          initial_state: READY
+    - type: image
+    - type: tcp
+    - type: rtmp
+      props:
+          uri: rtmp://domain/path/name
+```
+
+Each output must have a type (either 'rtmp', 'tcp', 'image', 'file', 'local', or 'webrtc').
+
+Each output can then, optionally, have `props` containing key-values pairs of the properties of that input. Available properties vary per output. All outputs have the following properties:
+
+* `width` - the width of the output.
+* `height` - the height of the output.
+* `intial_state` - the state that the output should enter. Permitted values: 'PLAYING', 'PAUSED', 'READY', 'NULL. Defaults to PLAYING.
+
+### `default_overlays`
+`default_overlays` is an array of overlays that should be created when 
+Brave starts.
+
+Example:
+
+```
+default_overlays:
+    - type: text
+      props:
+          text: 'I am some text'
+          visible: true
+    - type: effect
+      props:
+	I      effect_name: warptv
+```
+
+Each overlay must have a type (either 'text', 'clock', or 'effect').
+
+Each overlay can then, optionally, have `props` containing key-values pairs of the properties of that input. Available properties vary per overlay type, and include:
+
+* `visible` - whether the overlay is currently visible. Can be either `true` or `false`.
+* `effect_name` - only for the `effect` type. Valid values include `agingtv`, `warptv`, and `rippletv`. See the full list in the code [here](../brave/overlays/effect.py).
+
+### `enable_video` and `enable_audio`
+By default Brave handles video and audio. To disable audio, add the line:
+
+```
+enable_audio: false
+```
+
+To disable video, add the line:
+
+```
+enable_video: false
+```
+
+Note that audio and video cannot be enabled/disabled via the API.
+
+### `default_mixer_height` and `default_mixer_width`
+These allow you to set the default width and height for a mixer.
+The default is a width of 640 and a height of 360.
+

--- a/public/js/preview.js
+++ b/public/js/preview.js
@@ -96,7 +96,6 @@ preview._handlePreviewRequest = function(request) {
         outputsHandler._requestNewImageOutput()
     }
     else if (!isNaN(parseInt(request))) {
-        console.log('TEMP yay a number', request)
         const outputId = parseInt(request)
         const output = outputsHandler.findById(outputId)
         if (!output) {

--- a/tests/test_initial_state.py
+++ b/tests/test_initial_state.py
@@ -1,0 +1,105 @@
+import time, pytest, inspect
+from utils import *
+
+
+def test_initial_state_option_on_startup(run_brave, create_config_file):
+    '''
+    Test that if 'initial_state' is set as a property, it is honored.
+    It can be set for inputs, outputs and mixers.
+    '''
+    output_image_location0 = create_output_image_location()
+    output_image_location1 = create_output_image_location()
+
+    config = {
+    'default_inputs': [
+        {'type': 'test_video', 'props': {'pattern': 4, 'initial_state': 'PLAYING'}},
+        {'type': 'test_video', 'props': {'pattern': 5, 'initial_state': 'PAUSED'}},
+        {'type': 'test_video', 'props': {'pattern': 6, 'initial_state': 'READY'}},
+        {'type': 'test_video', 'props': {'pattern': 7, 'initial_state': 'NULL'}},
+    ],
+    'default_mixers': [
+        {'props': {'initial_state': 'PLAYING'}},
+        {'props': {'initial_state': 'PAUSED'}},
+        {'props': {'initial_state': 'READY'}},
+        {'props': {'initial_state': 'NULL'}},
+    ],
+    'default_outputs': [
+        {'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'PLAYING'}},
+        {'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'PAUSED'}},
+        {'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'READY'}},
+        {'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'NULL'}},
+    ]
+    }
+    config_file = create_config_file(config)
+    run_brave(config_file.name)
+    time.sleep(2)
+    check_brave_is_running()
+    response = api_get('/api/all')
+    assert response.status_code == 200
+    details = response.json()
+    assert details['inputs'][0]['state'] == 'PLAYING'
+    assert details['inputs'][1]['state'] == 'PAUSED'
+    assert details['inputs'][2]['state'] == 'READY'
+    assert details['inputs'][3]['state'] == 'NULL'
+    assert details['mixers'][0]['state'] == 'PLAYING'
+    assert details['mixers'][1]['state'] == 'PAUSED'
+    assert details['mixers'][2]['state'] == 'READY'
+    assert details['mixers'][3]['state'] == 'NULL'
+    assert details['outputs'][0]['state'] == 'PLAYING'
+    assert details['outputs'][1]['state'] == 'PAUSED'
+    assert details['outputs'][2]['state'] == 'READY'
+    assert details['outputs'][3]['state'] == 'NULL'
+
+
+def test_initial_state_option_via_api(run_brave):
+    '''
+    Test that if 'initial_state' is set as a property, it is honored.
+    It can be set for inputs, outputs and mixers.
+    '''
+    run_brave()
+    check_brave_is_running()
+    response = api_get('/api/all')
+    assert response.status_code == 200
+    assert_everything_in_playing_state(response.json())
+    output_image_location0 = create_output_image_location()
+
+    add_input({'type': 'test_audio', 'props': {'initial_state': 'NULL'}})
+    add_input({'type': 'test_audio', 'props': {'initial_state': 'READY'}})
+    add_input({'type': 'test_audio', 'props': {'initial_state': 'PAUSED'}})
+    add_input({'type': 'test_audio', 'props': {'initial_state': 'PLAYING'}})
+
+    # TODO Uncomment when the API adds support for creating new mixers
+    # add_mixer({'props': {'initial_state': 'NULL'}})
+    # add_mixer({'props': {'initial_state': 'READY'}})
+    # add_mixer({'props': {'initial_state': 'PAUSED'}})
+    # add_mixer({'props': {'initial_state': 'PLAYING'}})
+
+    add_output({'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'NULL'}})
+    add_output({'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'READY'}})
+    add_output({'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'PAUSED'}})
+    add_output({'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'PLAYING'}})
+
+    time.sleep(1)
+
+    response = api_get('/api/all')
+    assert response.status_code == 200
+    details = response.json()
+    print(response.json())
+    assert details['inputs'][0]['state'] == 'NULL'
+    assert details['inputs'][1]['state'] == 'READY'
+    assert details['inputs'][2]['state'] == 'PAUSED'
+    assert details['inputs'][3]['state'] == 'PLAYING'
+
+    # Mixer 0 is the default:
+    assert details['mixers'][0]['state'] == 'PLAYING'
+
+    # TODO Uncomment when the API adds support for creating new mixers
+    # assert details['mixers'][1]['state'] == 'NULL'
+    # assert details['mixers'][2]['state'] == 'READY'
+    # assert details['mixers'][3]['state'] == 'PAUSED'
+    # assert details['mixers'][4]['state'] == 'PLAYING'
+
+    assert details['outputs'][0]['state'] == 'NULL'
+    assert details['outputs'][1]['state'] == 'READY'
+    assert details['outputs'][2]['state'] == 'PAUSED'
+    assert details['outputs'][3]['state'] == 'PLAYING'


### PR DESCRIPTION
Addresses four ares:

1. Allows the user to specify what state a newly created input/output/mixer is. Previously, all would start PLAYING. Now, an ‘initial_state’ property can allow it to be PAUSED or READY (or even NULL, if somehow that's wanted).
2. Stops a race condition where an input can enter PLAYING before the bus has initialised, which resulted in some events being missed and thus certain elements not being unblocked.
3. Removes an anomaly where the RTMP output would enter PAUSED rather than PLAYING.
4. Documents the config file.

- [x] tests pass
- [x] linting passes
- [x] test written