### PR TITLE
Ability to create and delete mixers

### DIFF
--- a/brave/api/__init__.py
+++ b/brave/api/__init__.py
@@ -43,6 +43,7 @@ class RestApi(object):
         app.add_route(route_handler.create_input, '/api/inputs', methods=['PUT'])
         app.add_route(route_handler.create_output, '/api/outputs', methods=['PUT'])
         app.add_route(route_handler.create_overlay, '/api/overlays', methods=['PUT'])
+        app.add_route(route_handler.create_mixer, '/api/mixers', methods=['PUT'])
 
         app.add_route(route_handler.update_input, '/api/inputs/<id:int>', methods=['POST'])
         app.add_route(route_handler.update_output, '/api/outputs/<id:int>', methods=['POST'])
@@ -52,6 +53,7 @@ class RestApi(object):
         app.add_route(route_handler.delete_input, '/api/inputs/<id:int>', methods=['DELETE'])
         app.add_route(route_handler.delete_output, '/api/outputs/<id:int>', methods=['DELETE'])
         app.add_route(route_handler.delete_overlay, '/api/overlays/<id:int>', methods=['DELETE'])
+        app.add_route(route_handler.delete_mixer, '/api/mixers/<id:int>', methods=['DELETE'])
 
         app.add_route(route_handler.cut_to_source, '/api/mixers/<id:int>/cut_to_source', methods=['POST'])
         app.add_route(route_handler.overlay_source, '/api/mixers/<id:int>/overlay_source', methods=['POST'])

--- a/brave/api/route_handler.py
+++ b/brave/api/route_handler.py
@@ -84,7 +84,7 @@ async def cut_to_source(request, id):
         return _user_error_response('No such input ID')
 
     mixer = request['session'].mixers[id]
-    source = mixer.sources.get_or_create(request['session'].inputs[input_id])
+    source = mixer.sources.add(request['session'].inputs[input_id])
     if not source:
         return _user_error_response('Input is not source on mixer')
 
@@ -107,7 +107,7 @@ async def overlay_source(request, id):
         return _user_error_response('No such input ID')
 
     mixer = request['session'].mixers[id]
-    source = mixer.sources.get_or_create(request['session'].inputs[input_id])
+    source = mixer.sources.add(request['session'].inputs[input_id])
     if not source:
         return _user_error_response('Input is not source on mixer')
 

--- a/brave/api/route_handler.py
+++ b/brave/api/route_handler.py
@@ -7,81 +7,70 @@ from brave.helpers import state_string_to_constant, run_on_master_thread_when_id
 
 
 async def all(request):
-    session = brave.session.get_session()
     return sanic.response.json({
-        'inputs': session.inputs.summarise(),
-        'overlays': session.overlays.summarise(),
-        'outputs': session.outputs.summarise(),
-        'mixers': session.mixers.summarise()
+        'inputs': request['session'].inputs.summarise(),
+        'overlays': request['session'].overlays.summarise(),
+        'outputs': request['session'].outputs.summarise(),
+        'mixers': request['session'].mixers.summarise()
     })
 
 
 async def inputs(request):
-    session = brave.session.get_session()
-    return sanic.response.json(session.inputs.summarise())
+    return sanic.response.json(request['session'].inputs.summarise())
 
 
 async def outputs(request):
-    session = brave.session.get_session()
-    return sanic.response.json(session.outputs.summarise())
+    return sanic.response.json(request['session'].outputs.summarise())
 
 
 async def overlays(request):
-    session = brave.session.get_session()
-    return sanic.response.json(session.overlays.summarise())
+    return sanic.response.json(request['session'].overlays.summarise())
 
 
 async def mixers(request):
-    session = brave.session.get_session()
-    return sanic.response.json(session.mixers.summarise())
+    return sanic.response.json(request['session'].mixers.summarise())
 
 
 async def elements(request):
     show_inside_bin_elements = 'show_inside_bin_elements' in request.args
-    session = brave.session.get_session()
     return sanic.response.json({
-        'inputs': session.inputs.get_pipeline_details(show_inside_bin_elements),
-        'overlays': session.overlays.get_pipeline_details(show_inside_bin_elements),
-        'outputs': session.outputs.get_pipeline_details(show_inside_bin_elements),
-        'mixers': session.mixers.get_pipeline_details(show_inside_bin_elements)
+        'inputs': request['session'].inputs.get_pipeline_details(show_inside_bin_elements),
+        'overlays': request['session'].overlays.get_pipeline_details(show_inside_bin_elements),
+        'outputs': request['session'].outputs.get_pipeline_details(show_inside_bin_elements),
+        'mixers': request['session'].mixers.get_pipeline_details(show_inside_bin_elements)
     })
 
 
 async def delete_input(request, id):
-    session = brave.session.get_session()
-    if id not in session.inputs:
+    if id not in request['session'].inputs:
         return _user_error_response('No such input ID')
-    session.inputs[id].delete()
+    request['session'].inputs[id].delete()
     return _status_ok_response()
 
 
 async def delete_output(request, id):
-    session = brave.session.get_session()
-    if id not in session.outputs:
+    if id not in request['session'].outputs:
         return _user_error_response('No such output ID')
-    run_on_master_thread_when_idle(session.outputs[id].delete)
+    run_on_master_thread_when_idle(request['session'].outputs[id].delete)
     return _status_ok_response()
 
 
 async def delete_overlay(request, id):
-    session = brave.session.get_session()
-    if id not in session.overlays:
+    if id not in request['session'].overlays:
         return _user_error_response('No such overlay ID')
-    session.overlays[id].delete()
+    request['session'].overlays[id].delete()
     return _status_ok_response()
 
 
 async def delete_mixer(request, id):
-    session = brave.session.get_session()
-    if id not in session.mixers:
+    if id not in request['session'].mixers:
         return _user_error_response('No such mixer ID')
-    session.mixers[id].delete()
+    request['session'].mixers[id].delete()
     return _status_ok_response()
 
 
 async def cut_to_source(request, id):
-    session = brave.session.get_session()
-    if id not in session.mixers or session.mixers[id] is None:
+    if id not in request['session'].mixers or request['session'].mixers[id] is None:
         return _user_error_response('No such mixer ID')
     if not request.json:
         return _user_error_response('Invalid JSON')
@@ -91,11 +80,11 @@ async def cut_to_source(request, id):
         return _user_error_response('Only inputs can be added to a mixer')
 
     input_id = request.json['id']
-    if input_id not in session.inputs or session.inputs[input_id] is None:
+    if input_id not in request['session'].inputs or request['session'].inputs[input_id] is None:
         return _user_error_response('No such input ID')
 
-    mixer = session.mixers[id]
-    source = mixer.sources.get_for_input_or_mixer(session.inputs[input_id])
+    mixer = request['session'].mixers[id]
+    source = mixer.sources.get_or_create(request['session'].inputs[input_id])
     if not source:
         return _user_error_response('Input is not source on mixer')
 
@@ -104,8 +93,7 @@ async def cut_to_source(request, id):
 
 
 async def overlay_source(request, id):
-    session = brave.session.get_session()
-    if id not in session.mixers or session.mixers[id] is None:
+    if id not in request['session'].mixers or request['session'].mixers[id] is None:
         return _user_error_response('No such mixer ID')
     if not request.json:
         return _user_error_response('Invalid JSON')
@@ -115,11 +103,11 @@ async def overlay_source(request, id):
         return _user_error_response('Only inputs can be added to a mixer')
 
     input_id = request.json['id']
-    if input_id not in session.inputs or session.inputs[input_id] is None:
+    if input_id not in request['session'].inputs or request['session'].inputs[input_id] is None:
         return _user_error_response('No such input ID')
 
-    mixer = session.mixers[id]
-    source = mixer.sources.get_for_input_or_mixer(session.inputs[input_id])
+    mixer = request['session'].mixers[id]
+    source = mixer.sources.get_or_create(request['session'].inputs[input_id])
     if not source:
         return _user_error_response('Input is not source on mixer')
 
@@ -128,8 +116,7 @@ async def overlay_source(request, id):
 
 
 async def remove_source(request, id):
-    session = brave.session.get_session()
-    if id not in session.mixers or session.mixers[id] is None:
+    if id not in request['session'].mixers or request['session'].mixers[id] is None:
         return _user_error_response('No such mixer ID')
     if not request.json:
         return _user_error_response('Invalid JSON')
@@ -139,11 +126,11 @@ async def remove_source(request, id):
         return _user_error_response('Only inputs can be added to a mixer')
 
     input_id = request.json['id']
-    if input_id not in session.inputs or session.inputs[input_id] is None:
+    if input_id not in request['session'].inputs or request['session'].inputs[input_id] is None:
         return _user_error_response('No such input ID')
 
-    mixer = session.mixers[id]
-    source = mixer.sources.get_for_input_or_mixer(session.inputs[input_id])
+    mixer = request['session'].mixers[id]
+    source = mixer.sources.get_for_input_or_mixer(request['session'].inputs[input_id])
     if not source:
         return _user_error_response('Input is not source on mixer')
 
@@ -152,125 +139,80 @@ async def remove_source(request, id):
 
 
 async def update_input(request, id):
-    session = brave.session.get_session()
-    if not request.json:
-        return _invalid_json_response()
-    if id not in session.inputs or session.inputs[id] is None:
+    if id not in request['session'].inputs or request['session'].inputs[id] is None:
         return _user_error_response('No such input ID')
 
     if 'state' in request.json:
         request.json['state'] = state_string_to_constant(request.json['state'])
         if not request.json['state']:
             return _user_error_response('Invalid state')
-    try:
-        session.inputs[id].update(request.json)
-    except brave.exceptions.InvalidConfiguration as e:
-        return _invalid_configuration_response(e)
+    request['session'].inputs[id].update(request.json)
     return _status_ok_response()
 
 
 async def update_output(request, id):
-    session = brave.session.get_session()
-    if not request.json:
-        return _user_error_response('Not valid JSON')
-    if id not in session.outputs or session.outputs[id] is None:
+    if id not in request['session'].outputs or request['session'].outputs[id] is None:
         return _user_error_response('no such output id')
     if 'state' in request.json:
         request.json['state'] = state_string_to_constant(request.json['state'])
         if not request.json['state']:
             return _user_error_response('Invalid state')
-    try:
-        session.outputs[id].update(request.json)
-    except brave.exceptions.InvalidConfiguration as e:
-        return _invalid_configuration_response(e)
+    request['session'].outputs[id].update(request.json)
     return _status_ok_response()
 
 
 async def update_overlay(request, id):
-    session = brave.session.get_session()
-    if not request.json:
-        return _invalid_json_response('Not valid JSON')
-    if id not in session.overlays or session.overlays[id] is None:
+    if id not in request['session'].overlays or request['session'].overlays[id] is None:
         return _user_error_response('No such overlay ID')
     if 'state' in request.json:
         request.json['state'] = state_string_to_constant(request.json['state'])
         if not request.json['state']:
             return _user_error_response('Invalid state')
-    try:
-        session.overlays[id].update(request.json)
-    except brave.exceptions.InvalidConfiguration as e:
-        return _invalid_configuration_response(e)
+    request['session'].overlays[id].update(request.json)
     return _status_ok_response()
 
 
 async def update_mixer(request, id):
-    session = brave.session.get_session()
-    if not request.json:
-        return _invalid_json_response()
-    if id not in session.mixers or session.mixers[id] is None:
+    if id not in request['session'].mixers or request['session'].mixers[id] is None:
         return _user_error_response('No such mixer ID')
     if 'state' in request.json:
         request.json['state'] = state_string_to_constant(request.json['state'])
         if not request.json['state']:
             return _user_error_response('Invalid state')
-    try:
-        session.mixers[id].update(request.json)
-    except brave.exceptions.InvalidConfiguration as e:
-        return _invalid_configuration_response(e)
+    request['session'].mixers[id].update(request.json)
     return _status_ok_response()
 
 
 async def create_input(request):
-    session = brave.session.get_session()
-    if not request.json:
-        return _invalid_json_response()
-    try:
-        input = session.inputs.add(**request.json)
-        # TODO not hard-code mixer 0:
-        run_on_master_thread_when_idle(input.sources()[0].add_to_mix)
-    except brave.exceptions.InvalidConfiguration as e:
-        return _invalid_configuration_response(e)
-    return _status_ok_response()
+    input = request['session'].inputs.add(**request.json)
+    # TODO find a better way to decide which mixers this new input should be added to
+    mixer = request['session'].mixers[0]
+    source = mixer.sources.get_or_create(input)
+    run_on_master_thread_when_idle(source.add_to_mix)
+    logger.info('Created input #%d with details %s' % (input.id, request.json))
+    return sanic.response.json({'id': input.id})
 
 
 async def create_output(request):
-    session = brave.session.get_session()
-    if not request.json:
-        return _invalid_json_response()
-    try:
-        output = session.outputs.add(**request.json)
-        output.link_from_source()
-    except brave.exceptions.InvalidConfiguration as e:
-        return _invalid_configuration_response(e)
-    logger.info('Created output #' + str(output.id) + ' with details ' + str(request.json))
-    return sanic.response.json({'status': 'OK', 'id': output.id})
+    output = request['session'].outputs.add(**request.json)
+    logger.info('Created output #%d with details %s' % (output.id, request.json))
+    return sanic.response.json({'id': output.id})
 
 
 async def create_overlay(request):
-    session = brave.session.get_session()
-    if not request.json:
-        return _invalid_json_response()
-    try:
-        overlay = session.overlays.add(**request.json)
-    except brave.exceptions.InvalidConfiguration as e:
-        return _invalid_configuration_response(e)
-    logger.info('Created overlay #' + str(overlay.id) + ' with details ' + str(request.json))
+    overlay = request['session'].overlays.add(**request.json)
+    logger.info('Created overlay #%d with details %s' % (overlay.id, request.json))
     return _status_ok_response()
 
 
 async def create_mixer(request):
-    session = brave.session.get_session()
-    if not request.json:
-        return _invalid_json_response()
-    try:
-        mixer = session.mixers.add(**request.json)
-    except brave.exceptions.InvalidConfiguration as e:
-        return _invalid_configuration_response(e)
-    return _status_ok_response()
+    mixer = request['session'].mixers.add(**request.json)
+    logger.info('Created mixer #%d with details %s' % (mixer.id, request.json))
+    return sanic.response.json({'id': mixer.id})
 
 
 async def restart(request):
-    run_on_master_thread_when_idle(brave.session.get_session().end, restart=True)
+    run_on_master_thread_when_idle(request['session'].end, restart=True)
     return _status_ok_response()
 
 
@@ -280,10 +222,6 @@ def _status_ok_response():
 
 def _user_error_response(e):
     return sanic.response.json({'error': str(e)}, 400)
-
-
-def _invalid_json_response():
-    return _user_error_response('Invalid JSON')
 
 
 def _invalid_configuration_response(e):

--- a/brave/api/route_handler.py
+++ b/brave/api/route_handler.py
@@ -71,6 +71,14 @@ async def delete_overlay(request, id):
     return _status_ok_response()
 
 
+async def delete_mixer(request, id):
+    session = brave.session.get_session()
+    if id not in session.mixers:
+        return _user_error_response('No such mixer ID')
+    session.mixers[id].delete()
+    return _status_ok_response()
+
+
 async def cut_to_source(request, id):
     session = brave.session.get_session()
     if id not in session.mixers or session.mixers[id] is None:
@@ -247,6 +255,17 @@ async def create_overlay(request):
     except brave.exceptions.InvalidConfiguration as e:
         return _invalid_configuration_response(e)
     logger.info('Created overlay #' + str(overlay.id) + ' with details ' + str(request.json))
+    return _status_ok_response()
+
+
+async def create_mixer(request):
+    session = brave.session.get_session()
+    if not request.json:
+        return _invalid_json_response()
+    try:
+        mixer = session.mixers.add(**request.json)
+    except brave.exceptions.InvalidConfiguration as e:
+        return _invalid_configuration_response(e)
     return _status_ok_response()
 
 

--- a/brave/api/route_handler.py
+++ b/brave/api/route_handler.py
@@ -185,10 +185,8 @@ async def update_mixer(request, id):
 
 async def create_input(request):
     input = request['session'].inputs.add(**request.json)
-    # TODO find a better way to decide which mixers this new input should be added to
-    mixer = request['session'].mixers[0]
-    source = mixer.sources.get_or_create(input)
-    run_on_master_thread_when_idle(source.add_to_mix)
+    # TODO not hard-code mixer 0:
+    run_on_master_thread_when_idle(input.sources()[0].add_to_mix)
     logger.info('Created input #%d with details %s' % (input.id, request.json))
     return sanic.response.json({'id': input.id})
 

--- a/brave/inputs/__init__.py
+++ b/brave/inputs/__init__.py
@@ -11,7 +11,9 @@ class InputCollection(AbstractCollection):
     def add(self, **args):
         args['id'] = self.get_new_id()
 
-        if args['type'] == 'uri':
+        if 'type' not in args:
+            raise brave.exceptions.InvalidConfiguration("Invalid input missing 'type'")
+        elif args['type'] == 'uri':
             input = UriInput(**args, collection=self)
         elif args['type'] == 'test_video':
             input = TestVideoInput(**args, collection=self)

--- a/brave/outputs/__init__.py
+++ b/brave/outputs/__init__.py
@@ -5,13 +5,16 @@ from brave.outputs.image import ImageOutput
 from brave.outputs.file import FileOutput
 from brave.outputs.webrtc import WebRTCOutput
 from brave.abstract_collection import AbstractCollection
+import brave.exceptions
 
 
 class OutputCollection(AbstractCollection):
     def add(self, **args):
         args['id'] = self.get_new_id()
 
-        if args['type'] == 'local':
+        if 'type' not in args:
+            raise brave.exceptions.InvalidConfiguration("Invalid output missing 'type'")
+        elif args['type'] == 'local':
             output = LocalOutput(**args, collection=self)
         elif args['type'] == 'rtmp':
             output = RTMPOutput(**args, collection=self)
@@ -24,7 +27,7 @@ class OutputCollection(AbstractCollection):
         elif args['type'] == 'webrtc':
             output = WebRTCOutput(**args, collection=self)
         else:
-            raise Exception(f"Invalid output type '{str(args['type'])}'")
+            raise brave.exceptions.InvalidConfiguration("Invalid output type '%s'" % args['type'])
 
         self._items[args['id']] = output
         return output

--- a/brave/overlays/__init__.py
+++ b/brave/overlays/__init__.py
@@ -3,7 +3,7 @@ from brave.overlays.effect import EffectOverlay
 from brave.overlays.clock import ClockOverlay
 from brave.abstract_collection import AbstractCollection
 from gi.repository import Gst
-
+import brave.exceptions
 import logging
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('brave.overlays')
@@ -18,14 +18,16 @@ class OverlayCollection(AbstractCollection):
     def add(self, **args):
         args['id'] = self.get_new_id()
 
-        if args['type'] == 'text':
+        if 'type' not in args:
+            raise brave.exceptions.InvalidConfiguration("Invalid output missing 'type'")
+        elif args['type'] == 'text':
             overlay = TextOverlay(**args, collection=self)
         elif args['type'] == 'effect':
             overlay = EffectOverlay(**args, collection=self)
         elif args['type'] == 'clock':
             overlay = ClockOverlay(**args, collection=self)
         else:
-            raise Exception(f"Invalid overlay type '{str(args['type'])}'")
+            raise brave.exceptions.InvalidConfiguration("Invalid overlay type '%s'" % args['type'])
 
         self._items[args['id']] = overlay
         return overlay

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
           </button>
           <div class="dropdown-menu">
             <a class="dropdown-item" href="#" id="new-input-button">Input</a>
+            <a class="dropdown-item" href="#" id="new-mixer-button">Mixer</a>
             <a class="dropdown-item" href="#" id="new-output-button">Output</a>
             <a class="dropdown-item" href="#" id="new-overlay-button">Overlay</a>
           </div>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -5,6 +5,7 @@
 function onPageLoad() {
     $(document).ready(function() {
         $('#new-input-button').click(inputsHandler.showFormToAdd)
+        $('#new-mixer-button').click(mixersHandler.create)
         $('#new-overlay-button').click(overlaysHandler.showFormToAdd)
         $('#new-output-button').click(outputsHandler.showFormToAdd)
         $('#refresh-page-button').click(updatePage)

--- a/public/js/mixers.js
+++ b/public/js/mixers.js
@@ -47,7 +47,9 @@ mixersHandler._asCard = (mixer) => {
 }
 
 mixersHandler._optionButtonsForMixer = (mixer) => {
-    return components.editButton().click(() => { mixersHandler.showFormToEdit(mixer); return false })
+    const editButton = components.editButton().click(() => { mixersHandler.showFormToEdit(mixer); return false })
+    const deleteButton = components.deleteButton().click(() => { mixersHandler.delete(mixer); return false })
+    return [editButton, deleteButton]
 }
 
 mixersHandler._mixerCardBody = (mixer) => {
@@ -123,6 +125,10 @@ mixersHandler._handleFormSubmit = function() {
     hideModal();
 }
 
+mixersHandler.create = () => {
+    mixersHandler._submitCreateOrEdit(null, {})
+}
+
 
 mixersHandler._submitCreateOrEdit = function (id, values) {
     var putOrPost = (id != null) ? 'POST' : 'PUT'
@@ -142,4 +148,21 @@ mixersHandler._submitCreateOrEdit = function (id, values) {
                 'Error updating mixer: ' + response.responseJSON.error : 'Error updating mixer')
         }
     });
+}
+
+mixersHandler.delete = function(mixer) {
+    $.ajax({
+        contentType: "application/json",
+        type: 'DELETE',
+        url: 'api/mixers/' + mixer.id,
+        dataType: 'json',
+        success: function() {
+            showMessage('Successfully deleted mixer ' + mixer.id, 'success')
+            updatePage()
+        },
+        error: function() {
+            showMessage('Sorry, an error occurred whlst deleting mixer ' + mixer.id, 'danger')
+        }
+    });
+    return false
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,6 +24,7 @@ def test_bad_body(run_brave):
 
 def test_missing_type(run_brave):
     run_brave()
-    response = api_post('/api/mixers', {})
-    # assert response.status_code == 400
-    assert response.json()['error'] == 'Invalid JSON not!'
+    response = api_put('/api/inputs', {})
+    assert response.status_code == 400
+    print('text=', response.text)
+    assert "input missing 'type'" in response.json()['error']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,29 @@
+import time, pytest, inspect
+from utils import *
+from PIL import Image
+
+'''
+Some core API testing
+'''
+
+def test_404(run_brave):
+    run_brave()
+    response = api_get('/api/overlays')
+    assert response.status_code == 200
+    response = api_get('/api/bad-api-path')
+    assert response.status_code == 404
+    assert response.json()['error'] == 'Not found'
+
+
+def test_bad_body(run_brave):
+    run_brave()
+    response = api_post('/api/overlays', 'This is not a JSON object')
+    assert response.status_code == 400
+    assert response.json()['error'] == 'Invalid JSON'
+
+
+def test_missing_type(run_brave):
+    run_brave()
+    response = api_post('/api/mixers', {})
+    # assert response.status_code == 400
+    assert response.json()['error'] == 'Invalid JSON not!'

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -19,7 +19,7 @@ def test_image_input_from_command_line(run_brave, create_config_file):
     run_brave(config_file.name)
     time.sleep(0.5)
     check_brave_is_running()
-    time.sleep(1.5)
+    time.sleep(2)
     response = api_get('/api/all')
     assert response.status_code == 200
     assert_everything_in_playing_state(response.json())

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -9,6 +9,7 @@ def test_inputs(run_brave):
 
     # Create input, ignore attempts to set an ID
     add_input({'type': 'test_video', 'id': 99})
+    time.sleep(2)
     assert_inputs([{'type': 'test_video', 'id': 0}])
 
     # Different types of inputs work:

--- a/tests/test_mixers.py
+++ b/tests/test_mixers.py
@@ -10,7 +10,8 @@ def test_mixer_from_config(run_brave, create_config_file):
     subtest_assert_two_mixers(mixer_0_props={'width': 160, 'height': 90, 'pattern': 7})
     subtest_change_width_and_height()
     subtest_assert_two_mixers(mixer_0_props={'width': 200, 'height': 300, 'pattern': 7})
-
+    subtest_delete_mixers()
+    subtest_delete_nonexistant_mixer()
 
 def subtest_start_brave_with_mixers(run_brave, create_config_file):
     MIXER0 = {
@@ -40,5 +41,31 @@ def subtest_assert_two_mixers(mixer_0_props):
 def subtest_change_mixer_pattern():
     update_mixer(0, {'props': {'pattern': 7}})
 
+
 def subtest_change_width_and_height():
     update_mixer(0, {'props': {'width': 200, 'height': 300}})
+
+
+
+def subtest_delete_mixers():
+    delete_mixer(0)
+    delete_mixer(1)
+    assert_mixers([])
+
+
+def subtest_delete_nonexistant_mixer():
+    delete_mixer(2, 400)
+
+
+def test_mixer_from_api(run_brave):
+    run_brave()
+
+    # There is one mixer by default
+    assert_mixers([{'id': 0, 'props': {'width': 640, 'height': 360}}])
+
+    # Create input, ignore attempts to set an ID
+    add_mixer({'props': {'width': 200, 'height': 200}})
+    time.sleep(1)
+    assert_mixers([{'id': 0, 'props': {'width': 640, 'height': 360}},
+                   {'id': 1, 'props': {'width': 200, 'height': 200}}])
+    subtest_delete_mixers()

--- a/tests/test_mixers.py
+++ b/tests/test_mixers.py
@@ -46,7 +46,6 @@ def subtest_change_width_and_height():
     update_mixer(0, {'props': {'width': 200, 'height': 300}})
 
 
-
 def subtest_delete_mixers():
     delete_mixer(0)
     delete_mixer(1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -255,6 +255,12 @@ def update_input(id, updates, expected_status_code=200):
     time.sleep(0.2)
 
 
+def add_mixer(details):
+    response = api_put('/api/mixers', details)
+    assert response.status_code == 200
+    time.sleep(0.2)
+
+
 def update_mixer(id, updates, expected_status_code=200):
     response = api_post('/api/mixers/' + str(id), updates)
     assert response.status_code == expected_status_code

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -285,8 +285,8 @@ def assert_inputs(inputs, check_playing_state=True):
                 assert value == actual_input[key], 'For key "%s", expected "%s" but got "%s"' % (key, value, actual_input[key])
 
 
-def delete_input(id, expected_status_code=200):
-    response = api_delete('/api/inputs/' + str(id))
+def delete_mixer(id, expected_status_code=200):
+    response = api_delete('/api/mixers/' + str(id))
     assert response.status_code == expected_status_code
     time.sleep(0.2)
 


### PR DESCRIPTION
Ability to create a mixer with a PUT to `/api/mixers`
(matches the PUT to /api/inputs, /api/outputs, and /api/overlays)

Also the ability to delete a mixer with a DELETE to `/api/mixers/<ID>`
(matches how you delete inputs, outputs, and overlays)

Also the GUI updates to use it:

![image](https://user-images.githubusercontent.com/3178238/48402713-35aa6b00-e724-11e8-9abc-0ec3388c0e28.png)

Note that inputs can only be routed to the mixer 0... I'm going to address that in a separate branch.
