### PR TITLE
add HOST config, this allows to listen on other interfaces

### DIFF
--- a/brave/api/__init__.py
+++ b/brave/api/__init__.py
@@ -83,7 +83,7 @@ class RestApi(object):
         def start_server():
             asyncio.set_event_loop(uvloop.new_event_loop())
             loop = asyncio.get_event_loop()
-            server = app.create_server(port=config.api_port(), access_log=False)
+            server = app.create_server(host=config.api_host(), port=config.api_port(), access_log=False)
             asyncio.ensure_future(server)
             loop.create_task(self.webockets_handler.periodic_check())
             loop.run_forever()

--- a/brave/config.py
+++ b/brave/config.py
@@ -16,6 +16,12 @@ def init(filename=DEFAULT_CONFIG_FILENAME):
         exit(1)
 
 
+def api_host():
+    if 'HOST' in os.environ:
+        return os.environ['HOST']
+    return c['api_host'] if 'api_host' in c else '127.0.0.1'
+
+
 def api_port():
     if 'PORT' in os.environ:
         return int(os.environ['PORT'])


### PR DESCRIPTION
Today brave only listen on localhost:PORT. This change will allow the user to listen on another interface even on 0.0.0.0.
Listening on 0.0.0.0 helps to EXPOSE the port on a docker container.