### PR TITLE
Fix playing inputs being routed to multiple mixers

### DIFF
--- a/brave/helpers.py
+++ b/brave/helpers.py
@@ -53,6 +53,8 @@ def get_pipeline_details(pipeline, show_inside_bin_elements=True):
             inter_elements = ['interaudiosrc', 'interaudiosink', 'intervideosrc', 'intervideosink']
             if details['type'] in inter_elements:
                 details['channel'] = element.get_property('channel')
+            if details['type'] == 'queue':
+                details['current-level-time'] = element.get_property('current-level-time')
 
         def handle_pad(pad):
             details['pads'][pad.name] = {
@@ -107,7 +109,8 @@ def run_on_master_thread_when_idle(func, **func_args):
             func_args = args['func_args']
             f(**func_args)
         except Exception as e:
-            print("ERROR: Unexpected error whilst running in master thread:", e)
+            print('------------ UNCAUGHT EXCEPTION ON MASTER THREAD: %s ------------' % e)
+
         return False
 
     if func is None:

--- a/brave/inputs/input.py
+++ b/brave/inputs/input.py
@@ -90,6 +90,8 @@ class Input(InputOutputOverlay):
         if mixer:
             mix_width, mix_height = mixer.get_dimensions()
 
+        # An internal format of 'RGBA' ensures alpha support and no color variation.
+        # It then may be set to something else on output (e.g. I420)
         caps_string = 'video/x-raw,pixel-aspect-ratio=1/1,format=RGBA'
         if width and height:
             caps_string += ',width=%d,height=%d' % (width, height)

--- a/brave/mixers/mixer.py
+++ b/brave/mixers/mixer.py
@@ -137,7 +137,9 @@ class Mixer(InputOutputOverlay):
             self.videotestsrc.set_property('pattern', self.props['pattern'])
 
     def _set_dimensions(self):
-        dimensions_caps_string = 'video/x-raw,width=%s,height=%s' % (self.props['width'], self.props['height'])
+        # An internal format of 'RGBA' ensures alpha support and no color variation.
+        # It then may be set to something else on output (e.g. I420)
+        dimensions_caps_string = 'video/x-raw,pixel-aspect-ratio=1/1,format=RGBA,width=%s,height=%s' % (self.props['width'], self.props['height'])
         self.logger.debug('Dimensions caps: ' + dimensions_caps_string)
         dimensions_caps = Gst.Caps.from_string(dimensions_caps_string)
         self.capsfilter.set_property('caps', dimensions_caps)

--- a/brave/overlays/effect.py
+++ b/brave/overlays/effect.py
@@ -8,10 +8,7 @@ class EffectOverlay(Overlay):
 
     def permitted_props(self):
         return {
-            'mixer_id': {
-                'type': 'int',
-                'default': 0
-            },
+            **super().permitted_props(),
             'effect_name': {
                 'type': 'str',
                 'default': 'edgetv',

--- a/brave/pipeline_messaging.py
+++ b/brave/pipeline_messaging.py
@@ -52,7 +52,7 @@ def setup_messaging(pipe, parent_object):
             pass
         elif t == Gst.MessageType.ELEMENT:
             # Omit audio from 'level' element as it is very noisy:
-            if message.src.get_name() != 'level0':
+            if message.src.get_factory().name != 'level':
                 logger.debug(f'{str(message.src.get_name())} has a message:' + str(message.get_structure().to_string()))
         elif t == Gst.MessageType.DURATION_CHANGED:
             logger.debug(f'Duration changed to ' + str(pipe.query_duration(Gst.Format.TIME).duration) + 'ns')

--- a/brave/session.py
+++ b/brave/session.py
@@ -50,7 +50,8 @@ class Session(object):
             output.set_state(Gst.State.NULL)
         for name, mixer in self.mixers.items():
             mixer.set_state(Gst.State.NULL)
-        self.mainloop.quit()
+        if hasattr(self, 'mainloop'):
+            self.mainloop.quit()
         if restart:
             os.execl(sys.executable, sys.executable, *sys.argv)
 

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -58,7 +58,7 @@ default_mixers:
     - props:
         width: 640
         height: 360
-        pattern: 6	
+        pattern: 6
 ```
 
 Unlike inputs and outputs, mixers do not have a type.
@@ -94,9 +94,10 @@ Each output can then, optionally, have `props` containing key-values pairs of th
 * `width` - the width of the output.
 * `height` - the height of the output.
 * `intial_state` - the state that the output should enter. Permitted values: 'PLAYING', 'PAUSED', 'READY', 'NULL. Defaults to PLAYING.
+* `mixer_id` - the ID of the mixer that the output should treat as a source. If not set, defaults to mixer 0.
 
 ### `default_overlays`
-`default_overlays` is an array of overlays that should be created when 
+`default_overlays` is an array of overlays that should be created when
 Brave starts.
 
 Example:
@@ -137,4 +138,3 @@ Note that audio and video cannot be enabled/disabled via the API.
 ### `default_mixer_height` and `default_mixer_width`
 These allow you to set the default width and height for a mixer.
 The default is a width of 640 and a height of 360.
-

--- a/public/elements_table.html
+++ b/public/elements_table.html
@@ -29,6 +29,7 @@ function elementColumns(element) {
     cells.push($('<td></td>').append(element.state).addClass(element.state))
     var properties = []
     if (element.channel) properties.push('Channel: "' + element.channel + '"')
+    if (element.hasOwnProperty('current-level-time')) properties.push('Current level time: ' + element['current-level-time']/1000000 + 'ms')
     cells.push($('<td></td>').append(properties.join('<br />')))
     return cells
 }

--- a/tests/test_add_and_remove_from_mix.py
+++ b/tests/test_add_and_remove_from_mix.py
@@ -31,11 +31,11 @@ def test_removing_input_whilst_in_a_mix(run_brave, create_config_file):
 def test_switching(run_brave, create_config_file):
     set_up_two_sources(run_brave, create_config_file)
     assert_api_returns_right_mixer_sources([{'id': 0, 'type': 'input', 'in_mix': True}, {'id': 1, 'type': 'input', 'in_mix': True}])
-    cut_to_source(1)
+    cut_to_source(1, 0)
     assert_api_returns_right_mixer_sources([{'id': 0, 'type': 'input', 'in_mix': False}, {'id': 1, 'type': 'input', 'in_mix': True}])
-    cut_to_source(0)
+    cut_to_source(0, 0)
     assert_api_returns_right_mixer_sources([{'id': 0, 'type': 'input', 'in_mix': True}, {'id': 1, 'type': 'input', 'in_mix': False}])
-    cut_to_source(0)
+    cut_to_source(0, 0)
     assert_api_returns_right_mixer_sources([{'id': 0, 'type': 'input', 'in_mix': True}, {'id': 1, 'type': 'input', 'in_mix': False}])
 
 def set_up_two_sources(run_brave, create_config_file):
@@ -75,12 +75,6 @@ def remove_source(input_id):
 
 def overlay_source(input_id):
     response = api_post('/api/mixers/0/overlay_source', {'id': input_id, 'type': 'input'})
-    assert response.status_code == 200
-    time.sleep(0.5)
-
-
-def cut_to_source(input_id):
-    response = api_post('/api/mixers/0/cut_to_source', {'id': input_id, 'type': 'input'})
     assert response.status_code == 200
     time.sleep(0.5)
 

--- a/tests/test_image_output.py
+++ b/tests/test_image_output.py
@@ -23,4 +23,4 @@ def test_image_output(run_brave, create_config_file):
     assert_everything_in_playing_state(response.json())
 
 
-    assert_image_color(output_image_location, (255,0,0))
+    assert_image_file_color(output_image_location, (255,0,0))

--- a/tests/test_initial_state.py
+++ b/tests/test_initial_state.py
@@ -32,7 +32,7 @@ def test_initial_state_option_on_startup(run_brave, create_config_file):
     }
     config_file = create_config_file(config)
     run_brave(config_file.name)
-    time.sleep(3)
+    time.sleep(4)
     check_brave_is_running()
     response = api_get('/api/all')
     assert response.status_code == 200

--- a/tests/test_multiple_inputs_and_mixers.py
+++ b/tests/test_multiple_inputs_and_mixers.py
@@ -1,0 +1,117 @@
+import time, pytest, inspect
+from utils import *
+from PIL import Image
+
+'''
+This test ensures that if there are multiple mixers, sharing multiple playing inputs,
+they all successfully share without imacting each other.
+'''
+
+
+MIXER0 = {
+    'width': 160,
+    'height': 90,
+    'pattern': 6
+}
+MIXER1 = {
+    'width': 640,
+    'height': 360
+}
+
+# INPUT0 is RED and INPUT1 is GREEN:
+INPUT0 = {'type': 'test_video', 'props': { 'pattern': 4, 'zorder': 10 } }
+INPUT1 = {'type': 'test_video', 'props': { 'pattern': 5, 'zorder': 20 } }
+OUTPUT0 = {'type': 'image', 'props': {'mixer_id': 0}}
+OUTPUT1 = {'type': 'image', 'props': {'mixer_id': 1}}
+
+
+def test_mixer_from_config(run_brave, create_config_file):
+    subtest_start_brave_with_mixers(run_brave, create_config_file)
+
+    # Both mixers will be green because green INPUT1 has a higher zorder
+    assert_image_output_color(0, [0, 255, 0])
+    assert_image_output_color(1, [0, 255, 0])
+
+    subtest_ensure_one_mixer_does_not_affect_another()
+    subtest_addition_of_input()
+    subtest_overlay_of_new_input()
+
+    subtest_addition_of_mixer()
+    subtest_addition_of_destination_to_new_mixer()
+    subtest_overlay_of_input_onto_new_mixer()
+
+
+def subtest_ensure_one_mixer_does_not_affect_another():
+    # Set mixer0 to just use INPUT0. It should go RED, leaving mixer 1 on GREEN:
+    cut_to_source(0, 0)
+    time.sleep(3)
+    assert_image_output_color(0, [255, 0, 0])
+    assert_image_output_color(1, [0, 255, 0])
+
+
+def subtest_addition_of_input():
+    # Create a third input. This is BLUE
+    add_input({'type': 'test_video', 'props': {'pattern': 6, 'zorder': 30}})
+    time.sleep(3)
+
+    # The current rule is that mixer 0 gets the input automatically. Mixer 1 does not.
+    # So ouput 0 should not be blue, but output 1 should still be green
+    assert_image_output_color(0, [0, 0, 255])
+    assert_image_output_color(1, [0, 255, 0])
+
+
+def subtest_overlay_of_new_input():
+    cut_to_source(2, 1)
+    time.sleep(3)
+
+    # Both outputs should now be showing blue, as they are all showing input 2
+    assert_image_output_color(0, [0, 0, 255])
+    assert_image_output_color(1, [0, 0, 255])
+
+
+def subtest_start_brave_with_mixers(run_brave, create_config_file):
+    config = {
+        'default_mixers': [{'props': MIXER0}, {'props': MIXER1}],
+        'default_inputs': [INPUT0, INPUT1],
+        'default_outputs': [OUTPUT0, OUTPUT1]
+    }
+    config_file = create_config_file(config)
+    run_brave(config_file.name)
+    check_brave_is_running()
+    time.sleep(4)
+    assert_mixers([
+        {'id': 0, 'props': MIXER0 },
+        {'id': 1, 'props': MIXER1 }
+    ])
+    assert_inputs([INPUT0, INPUT1])
+    assert_outputs([OUTPUT0, OUTPUT1])
+
+
+def subtest_addition_of_mixer():
+    add_mixer({})
+    time.sleep(3)
+    response = api_get('/api/all')
+    assert response.status_code == 200
+    assert_everything_in_playing_state(response.json())
+    response_json = response.json()
+
+    # By default, a new mixer gets no sources:
+    assert response_json['mixers'][2]['sources'] == []
+
+
+def subtest_addition_of_destination_to_new_mixer():
+    add_output({'type': 'image', 'props': {'mixer_id': 2}})
+    time.sleep(2)
+    response = api_get('/api/all')
+    assert response.status_code == 200
+    assert_everything_in_playing_state(response.json())
+
+
+def subtest_overlay_of_input_onto_new_mixer():
+    cut_to_source(2, 2)
+    time.sleep(2)
+
+    # Now all three outputs will be input 2, i.e. blue
+    assert_image_output_color(0, [0, 0, 255])
+    assert_image_output_color(1, [0, 0, 255])
+    assert_image_output_color(2, [0, 0, 255])

--- a/tests/test_multiple_outputs.py
+++ b/tests/test_multiple_outputs.py
@@ -35,8 +35,8 @@ def test_multiple_outputs_at_startup(run_brave, create_config_file):
 
     # If they've linked right, one will be red and the other will be green
     time.sleep(2)
-    assert_image_color(output_image_location0, (0,255,0))
-    assert_image_color(output_image_location1, (255,0,0))
+    assert_image_file_color(output_image_location0, (0,255,0))
+    assert_image_file_color(output_image_location1, (255,0,0))
 
 def test_output_at_startup_to_missing_mixer(run_brave, create_config_file):
     config = {


### PR DESCRIPTION
It was not previously possible to add a playing input into more than one mixer.
This fixes this bug.

Test written to stop this happening again!

- [x] Test passing
- [x] Code linted
- [x] Test written