### PR TITLE
Improved stun and turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ Provide another config with the `-c` parameter, e.g.
 
 See the [Config File](./docs/config_file.md) documentation for more.
 
+#### STUN and TURN servers for WebRTC
+A STUN or TURN server is likely required for Brave's WebRTC to work between remote connections.
+Brave defaults to Google's public STUN server; this can be overridden in the [config file](./docs/config_file.md), or by setting the `STUN_SERVER` environment variable. Likewise, a `TURN_SERVER` environment variable can be set if a TURN server is required. Its value should be in the format `<usernane>:<credential>@<host>:<port>`.
+
 ## Tests
 Brave has functional black-box tests that ensure the config file and API is working correctly.
 To run them:

--- a/brave/config.py
+++ b/brave/config.py
@@ -78,7 +78,15 @@ def default_audio_caps():
     return 'audio/x-raw,channels=2,layout=interleaved,rate=48000,format=S16LE'
 
 
-def ice_servers():
-    return [
-        {'urls': 'stun:stun.services.mozilla.com'}
-    ]
+def stun_server():
+    'Should be in the format <host>:<port>'
+    if 'STUN_SERVER' in os.environ:
+        return os.environ['STUN_SERVER']
+    return c['stun_server'] if 'stun_server' in c else 'stun.l.google.com:19302'
+
+
+def turn_server():
+    'Should be in the format <username>:<credential>@<host>:<port>'
+    if 'TURN_SERVER' in os.environ:
+        return os.environ['TURN_SERVER']
+    return c['turn_server'] if 'turn_server' in c else None

--- a/brave/mixers/mixer.py
+++ b/brave/mixers/mixer.py
@@ -139,7 +139,8 @@ class Mixer(InputOutputOverlay):
     def _set_dimensions(self):
         # An internal format of 'RGBA' ensures alpha support and no color variation.
         # It then may be set to something else on output (e.g. I420)
-        dimensions_caps_string = 'video/x-raw,pixel-aspect-ratio=1/1,format=RGBA,width=%s,height=%s' % (self.props['width'], self.props['height'])
+        dimensions_caps_string = 'video/x-raw,pixel-aspect-ratio=1/1,format=RGBA,width=%s,height=%s' % \
+            (self.props['width'], self.props['height'])
         self.logger.debug('Dimensions caps: ' + dimensions_caps_string)
         dimensions_caps = Gst.Caps.from_string(dimensions_caps_string)
         self.capsfilter.set_property('caps', dimensions_caps)

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -138,3 +138,11 @@ Note that audio and video cannot be enabled/disabled via the API.
 ### `default_mixer_height` and `default_mixer_width`
 These allow you to set the default width and height for a mixer.
 The default is a width of 640 and a height of 360.
+
+### `stun_server` and `turn_server`
+Up to one STUN server and/or one TURN server can be provided. Example:
+
+```
+stun_server: stun.l.google.com:19302
+turn_server: my_name:my_password@my_turn_server_hostname
+```

--- a/public/js/preview.js
+++ b/public/js/preview.js
@@ -251,6 +251,11 @@ preview._createImage = function() {
     $('#preview-bar').append(image)
 }
 
+preview.showErrorMessage = msg => {
+    preview._delete()
+    $('#preview-bar').append($('<p />').html('ERROR: ' + msg))
+}
+
 preview._delete = () => {
     preview._deleteVideoPlayer()
     $('#preview-bar').empty()

--- a/public/js/webrtc.js
+++ b/public/js/webrtc.js
@@ -41,6 +41,9 @@ webrtc.createCall = function() {
     webrtc.peerConnection.oniceconnectionstatechange = () => {
         if (webrtc.peerConnection) {
             console.log('New ICE connection state:', webrtc.peerConnection.iceConnectionState)
+            if (webrtc.peerConnection.iceConnectionState === 'failed') {
+                preview.showErrorMessage('Failed to connect WebRTC with server')
+            }
         }
     }
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,37 @@
+import sys, os
+sys.path.append('tests')
+sys.path.append('.')
+from utils import create_config_file
+import brave.config
+
+'''
+Unit test for brave/config.py
+'''
+
+def test_stun_server_config(create_config_file):
+    config = {'stun_server': 'a-stun-server'}
+    config_file = create_config_file(config)
+    brave.config.init(config_file.name)
+    assert brave.config.stun_server() == 'a-stun-server'
+
+
+def test_stun_server_via_env_var():
+    os.environ['STUN_SERVER'] = 'a-stun-server-from-env-var'
+    brave.config.init()
+    assert brave.config.stun_server() == 'a-stun-server-from-env-var'
+
+
+def test_api_host_and_port_config(create_config_file):
+    config = {'api_host': 'api-host', 'api_port': 12345}
+    config_file = create_config_file(config)
+    brave.config.init(config_file.name)
+    assert brave.config.api_host() == 'api-host'
+    assert brave.config.api_port() == 12345
+
+
+def test_api_host_and_port_vir_env_var():
+    os.environ['HOST'] = 'host-via-env'
+    os.environ['PORT'] = '23456'
+    brave.config.init()
+    assert brave.config.api_host() == 'host-via-env'
+    assert brave.config.api_port() == 23456


### PR DESCRIPTION
Changes config to allow up to one STUN server and up to one TURN server. This matches what ‘webrtcbin’ accepts.

Also replaced the default STUN server from Mozilla to Google. This works better in my testing.

The result of this is that Brave WebRTC now works on remote servers without the need for a TURN server.

- [x] Tests passing
- [x] Code linted
- [x] Test written