### PR TITLE
Switch git pull protocol.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
     pkg-config \
     python3-dev python3-wheel python3-gst-1.0 python3-pip python3-gi
 
-RUN git clone --depth 1 git://github.com/bbc/brave.git && \
+RUN git clone --depth 1 https://github.com/bbc/brave.git && \
     cd brave && \
     pip3 install pipenv && \
     pipenv install --ignore-pipfile && \


### PR DESCRIPTION
Switch git pull to https - lets the build complete behind a proxy (such as Squid) when built using:

```
docker build --build-arg http_proxy=http://10.118.66.5:80 --build-arg https_proxy=http://10.118.66.5:80 -t bbc/brave:latest
```