### PR TITLE
Fixing 'Restart Brave' request

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -280,6 +280,9 @@ function restartBrave() {
     $.ajax({
         type: 'POST',
         url: 'api/restart',
+        body: "{}",
+        dataType: "json",
+        contentType: "application/json",
         success: function() {
             showMessage('Restart underway', 'success')
         },


### PR DESCRIPTION
Without a `body` the Ajax POST request fails. This PR just adds an empty body and sets `dataType` and the `"Content-Type"` header explicitly to expect json. 