### PR TITLE
Remove 'props' from api and config

### DIFF
--- a/brave/api/route_handler.py
+++ b/brave/api/route_handler.py
@@ -118,19 +118,19 @@ async def create_input(request):
 async def create_output(request):
     output = request['session'].outputs.add(**request.json)
     logger.info('Created output #%d with details %s' % (output.id, request.json))
-    return sanic.response.json({'id': output.id})
+    return sanic.response.json({'id': output.id, 'uid': output.uid()})
 
 
 async def create_overlay(request):
     overlay = request['session'].overlays.add(**request.json)
     logger.info('Created overlay #%d with details %s' % (overlay.id, request.json))
-    return _status_ok_response()
+    return sanic.response.json({'id': overlay.id, 'uid': overlay.uid()})
 
 
 async def create_mixer(request):
     mixer = request['session'].mixers.add(**request.json)
     logger.info('Created mixer #%d with details %s' % (mixer.id, request.json))
-    return sanic.response.json({'id': mixer.id})
+    return sanic.response.json({'id': mixer.id, 'uid': mixer.uid()})
 
 
 async def get_body(request, id):
@@ -143,7 +143,7 @@ async def get_body(request, id):
 
     try:
         return await sanic.response.file_stream(
-            output.props['location'],
+            output.location,
             headers={'Cache-Control': 'max-age=1'}
         )
     except FileNotFoundError:

--- a/brave/connections/connection_to_mixer.py
+++ b/brave/connections/connection_to_mixer.py
@@ -99,20 +99,20 @@ class ConnectionToMixer(Connection):
         if 'video' not in self._mix_request_pad:
             return
 
-        if 'xpos' in self.source.props:
-            self._mix_request_pad['video'].set_property('xpos', self.source.props['xpos'])
-        if 'ypos' in self.source.props:
-            self._mix_request_pad['video'].set_property('ypos', self.source.props['ypos'])
+        if hasattr(self.source, 'xpos'):
+            self._mix_request_pad['video'].set_property('xpos', self.source.xpos)
+        if hasattr(self.source, 'ypos'):
+            self._mix_request_pad['video'].set_property('ypos', self.source.ypos)
         self._set_mixer_width_and_height()
 
         # Setting zorder to what's already set can cause a segfault.
-        if 'zorder' in self.source.props:
+        if hasattr(self.source, 'zorder'):
             current_zorder = self._mix_request_pad['video'].get_property('zorder')
-            if current_zorder != self.source.props['zorder']:
+            if current_zorder != self.source.zorder:
                 self.logger.debug('Setting zorder to %d (current state: %s)' %
-                                  (self.source.props['zorder'],
+                                  (self.source.zorder,
                                    self.dest.mixer_element['video'].get_state(0).state.value_nick.upper()))
-                self._mix_request_pad['video'].set_property('zorder', self.source.props['zorder'])
+                self._mix_request_pad['video'].set_property('zorder', self.source.zorder)
 
     def _handle_audio_mix_props(self):
         '''
@@ -121,31 +121,31 @@ class ConnectionToMixer(Connection):
         if 'audio' not in self._mix_request_pad:
             return
 
-        if 'volume' in self.source.props:
+        if hasattr(self.source, 'volume'):
             prev_volume = self._mix_request_pad['audio'].get_property('volume')
-            volume = self.source.props['volume']
+            volume = self.source.volume
 
             if volume != prev_volume:
                 self._mix_request_pad['audio'].set_property('volume', float(volume))
 
     def _set_mixer_width_and_height(self):
         # First stage: go with mixer's size
-        width = self.dest.props['width']
-        height = self.dest.props['height']
+        width = self.dest.width
+        height = self.dest.height
 
         # Second stage: if input is smaller, go with that
-        if 'width' in self.source.props and self.source.props['width'] < width:
-            width = self.source.props['width']
-        if 'height' in self.source.props and self.source.props['height'] < height:
-            height = self.source.props['height']
+        if hasattr(self.source, 'width') and self.source.width < width:
+            width = self.source.width
+        if hasattr(self.source, 'height') and self.source.height < height:
+            height = self.source.height
 
         # Third stage: if positioned to go off the side, reduce the size.
-        if 'xpos' in self.source.props:
-            if width + self.source.props['xpos'] > self.dest.props['width']:
-                width = self.dest.props['width'] - self.source.props['xpos']
-        if 'ypos' in self.source.props:
-            if height + self.source.props['ypos'] > self.dest.props['height']:
-                height = self.dest.props['height'] - self.source.props['ypos']
+        if hasattr(self.source, 'xpos'):
+            if width + self.source.xpos > self.dest.width:
+                width = self.dest.width - self.source.xpos
+        if hasattr(self.source, 'ypos'):
+            if height + self.source.ypos > self.dest.height:
+                height = self.dest.height - self.source.ypos
 
         self._mix_request_pad['video'].set_property('width', width)
         self._mix_request_pad['video'].set_property('height', height)

--- a/brave/inputs/html.py
+++ b/brave/inputs/html.py
@@ -44,7 +44,7 @@ class HTMLInput(Input):
         if not config.enable_video():
             return
 
-        self.create_pipeline_from_string('cef url="' + self.props['uri'] + '" ! '
+        self.create_pipeline_from_string('cef url="' + self.uri + '" ! '
                                          ' videoconvert ! video/x-raw,format=ARGB ! '
                                          'queue' + self.default_video_pipeline_string_end())
 

--- a/brave/inputs/image.py
+++ b/brave/inputs/image.py
@@ -42,7 +42,7 @@ class ImageInput(Input):
             return
 
         # To crop (not resize): videobox autocrop=true border-alpha=0
-        pipeline_string = ('uridecodebin name=uridecodebin uri="' + self.props['uri'] +
+        pipeline_string = ('uridecodebin name=uridecodebin uri="' + self.uri +
                            '" ! imagefreeze ! videoconvert ! video/x-raw,pixel-aspect-ratio=1/1,framerate=30/1' +
                            self.default_video_pipeline_string_end())
         self.create_pipeline_from_string(pipeline_string)

--- a/brave/inputs/input.py
+++ b/brave/inputs/input.py
@@ -15,7 +15,7 @@ class Input(InputOutputOverlay):
         self.create_elements()
         self.handle_updated_props()
 
-        # Set initially to READY, and when there we set to self.props['initial_state']
+        # Set initially to READY, and when there we set to self.initial_state
         self.set_state(Gst.State.READY)
 
     def input_output_overlay_or_mixer(self):
@@ -69,8 +69,8 @@ class Input(InputOutputOverlay):
         '''
         Returns the preferred caps (a string defining things such as width, height and framerate)
         '''
-        width = self.props['width'] if 'width' in self.props else 0
-        height = self.props['height'] if 'height' in self.props else 0
+        width = self.width if hasattr(self, 'width') else 0
+        height = self.height if hasattr(self, 'height') else 0
 
         # An internal format of 'RGBA' ensures alpha support and no color variation.
         # It then may be set to something else on output (e.g. I420)

--- a/brave/inputs/test_audio.py
+++ b/brave/inputs/test_audio.py
@@ -34,7 +34,7 @@ class TestAudioInput(Input):
 
     def handle_updated_props(self):
         super().handle_updated_props()
-        if 'wave' in self.props:
-            self.audiotestsrc.set_property('wave', int(self.props['wave']))
-        if 'freq' in self.props:
-            self.audiotestsrc.set_property('freq', self.props['freq'])
+        if hasattr(self, 'wave'):
+            self.audiotestsrc.set_property('wave', int(self.wave))
+        if hasattr(self, 'freq'):
+            self.audiotestsrc.set_property('freq', self.freq)

--- a/brave/inputs/test_video.py
+++ b/brave/inputs/test_video.py
@@ -48,5 +48,5 @@ class TestVideoInput(Input):
 
     def handle_updated_props(self):
         super().handle_updated_props()
-        if 'pattern' in self.props:
-            self.videotestsrc.set_property('pattern', self.props['pattern'])
+        if hasattr(self, 'pattern'):
+            self.videotestsrc.set_property('pattern', self.pattern)

--- a/brave/inputs/uri.py
+++ b/brave/inputs/uri.py
@@ -41,7 +41,7 @@ class UriInput(Input):
 
     def create_elements(self):
         # Playbin does all the hard work
-        self.create_pipeline_from_string("playbin uri=\"" + self.props['uri'] + "\"")
+        self.create_pipeline_from_string("playbin uri=\"" + self.uri + "\"")
 
         # playbin appears as 'playsink' (because it's a bin with elements inside)
         self.playsink = self.pipeline.get_by_name('playsink')
@@ -83,8 +83,6 @@ class UriInput(Input):
         self.final_audio_tee = bin.get_by_name('final_audio_tee')
 
     def update(self, updates):
-        super().update(updates)
-
         # Special case: allow seeking
         if self.has_video() and 'position' in updates:
             try:
@@ -95,6 +93,9 @@ class UriInput(Input):
                     self.logger.warning('Unable to est position to %s' % new_position)
             except ValueError:
                 self.logger.warning('Invalid position %s provided' % updates['position'])
+            del updates['position']
+
+        super().update(updates)
 
     def get_input_cap_props(self):
         '''

--- a/brave/mixers/mixer.py
+++ b/brave/mixers/mixer.py
@@ -19,7 +19,7 @@ class Mixer(InputOutputOverlay):
         self.request_pad_count = {'video': 0, 'audio': 0}
         self.create_elements()
 
-        # Set initially to READY, and when there we set to self.props['initial_state']
+        # Set initially to READY, and when there we set to self.initial_state
         self.set_state(Gst.State.READY)
 
     def permitted_props(self):
@@ -36,6 +36,8 @@ class Mixer(InputOutputOverlay):
             'pattern': {
                 'type': 'int',
                 'default': 0
+            },
+            'sources': {
             },
         }
 
@@ -167,14 +169,14 @@ class Mixer(InputOutputOverlay):
         return self.mixer_element[audio_or_video].get_request_pad('sink_%d' % self.request_pad_count[audio_or_video])
 
     def handle_updated_props(self):
-        if 'pattern' in self.props:
-            self.videotestsrc.set_property('pattern', self.props['pattern'])
+        if hasattr(self, 'pattern'):
+            self.videotestsrc.set_property('pattern', self.pattern)
 
     def _set_dimensions(self):
         # An internal format of 'RGBA' ensures alpha support and no color variation.
         # It then may be set to something else on output (e.g. I420)
         dimensions_caps_string = 'video/x-raw,pixel-aspect-ratio=1/1,format=RGBA,width=%s,height=%s' % \
-            (self.props['width'], self.props['height'])
+            (self.width, self.height)
         self.logger.debug('Dimensions caps: ' + dimensions_caps_string)
         dimensions_caps = Gst.Caps.from_string(dimensions_caps_string)
         self.capsfilter.set_property('caps', dimensions_caps)

--- a/brave/outputs/file.py
+++ b/brave/outputs/file.py
@@ -40,9 +40,9 @@ class FileOutput(Output):
             pipeline_string = pipeline_string + ' ' + audio_pipeline_string
 
         self.create_pipeline_from_string(pipeline_string)
-        self.logger.debug('Writing to the file ' + self.props['location'])
+        self.logger.debug('Writing to the file ' + self.location)
         sink = self.pipeline.get_by_name('sink')
-        sink.set_property('location', self.props['location'])
+        sink.set_property('location', self.location)
 
         if config.enable_video():
             self.video_encoder = self.pipeline.get_by_name('video_encoder')

--- a/brave/outputs/image.py
+++ b/brave/outputs/image.py
@@ -35,7 +35,7 @@ class ImageOutput(Output):
         return False
 
     def create_caps_string(self):
-        return super().create_caps_string(format='RGB') + ',framerate=1/' + str(self.props['update_frequency'])
+        return super().create_caps_string(format='RGB') + ',framerate=1/' + str(self.update_frequency)
 
     def create_elements(self):
         if not config.enable_video():
@@ -44,10 +44,10 @@ class ImageOutput(Output):
         pipeline_string = self._video_pipeline_start() + 'jpegenc ! multifilesink name=sink'
         self.create_pipeline_from_string(pipeline_string)
         sink = self.pipeline.get_by_name('sink')
-        sink.set_property('location', self.props['location'])
+        sink.set_property('location', self.location)
 
     def __delete_file_if_exists(self):
         try:
-            os.remove(self.props['location'])
+            os.remove(self.location)
         except FileNotFoundError:
             pass

--- a/brave/outputs/kvs.py
+++ b/brave/outputs/kvs.py
@@ -44,7 +44,7 @@ class KvsOutput(Output):
         kvssink = self.pipeline.get_by_name('kvssink')
         kvssink.set_property('access-key', access_key)
         kvssink.set_property('secret-key', secret_key)
-        kvssink.set_property('stream-name', self.props['stream_name'])
+        kvssink.set_property('stream-name', self.stream_name)
 
     def create_caps_string(self):
         return super().create_caps_string(format='I420') + ',pixel-aspect-ratio=1/1,framerate=30/1'

--- a/brave/outputs/output.py
+++ b/brave/outputs/output.py
@@ -31,7 +31,7 @@ class Output(InputOutputOverlay):
 
         self._set_source(source_uid)
 
-        # Set initially to READY, and when there we set to self.props['initial_state']
+        # Set initially to READY, and when there we set to self.initial_state
         self.set_state(Gst.State.READY)
 
     def input_output_overlay_or_mixer(self):
@@ -84,6 +84,7 @@ class Output(InputOutputOverlay):
                 raise brave.exceptions.InvalidConfiguration(
                     'Cannot change an output\'s source whilst it is in PAUSED or PLAYING state')
             self._set_source(updates['source'])
+            del updates['source']
         super().update(updates)
 
     def delete(self):
@@ -101,8 +102,8 @@ class Output(InputOutputOverlay):
 
         # If only one dimension is provided, we calculate the other.
         # Some encoders (jpegenc, possibly others) don't like it if only one metric is present.
-        width = self.props['width'] if 'width' in self.props else None
-        height = self.props['height'] if 'height' in self.props else None
+        width = self.width if hasattr(self, 'width') else 0
+        height = self.height if hasattr(self, 'height') else 0
         if self.source():
             src_width, src_height = self.source().get_dimensions()
             if src_width and src_height:

--- a/brave/outputs/rtmp.py
+++ b/brave/outputs/rtmp.py
@@ -39,9 +39,9 @@ class RTMPOutput(Output):
                 'avenc_aac name=audio_encoder ! aacparse ! audio/mpeg, mpegversion=4 ! queue ! mux.'
 
         self.create_pipeline_from_string(pipeline_string)
-        self.pipeline.get_by_name('sink').set_property('location', self.props['uri'] + ' live=1')
+        self.pipeline.get_by_name('sink').set_property('location', self.uri + ' live=1')
 
-        self.logger.info('RTMP output now configured to send to ' + self.props['uri'])
+        self.logger.info('RTMP output now configured to send to ' + self.uri)
 
     def create_caps_string(self):
         # framerate=30/1 because Facebook Live and YouTube live want this framerate.

--- a/brave/outputs/webrtc.py
+++ b/brave/outputs/webrtc.py
@@ -53,7 +53,7 @@ class WebRTCOutput(Output):
         if config.enable_video():
 
             video_caps = 'application/x-rtp,format=RGB,media=video,encoding-name=VP8,payload=97,width=%d,height=%d' % \
-                (self.props['width'], self.props['height'])
+                (self.width, self.height)
 
             # vp8enc has 'target-bitrate' which can be reduced from its default (256000)
             # Setting keyframe-max-dist lower reduces impact of packet loss on dodgy networks

--- a/brave/overlays/effect.py
+++ b/brave/overlays/effect.py
@@ -45,7 +45,7 @@ class EffectOverlay(Overlay):
         # to remove the alpha channel, before moving back to our default RGBA.
         # This is done in a 'bin' so that the overlay can be manipulated as one thing.
         desc = ('videoconvert ! %s ! videoconvert ! capsfilter caps="video/x-raw,format=RGB" ! '
-                'videoconvert ! capsfilter caps="video/x-raw,format=RGBA"') % self.props['effect_name']
+                'videoconvert ! capsfilter caps="video/x-raw,format=RGBA"') % self.effect_name
         self.element = Gst.parse_bin_from_description(desc, True)
         self.element.set_name('%s_bin' % self.uid())
         place_to_add_elements = getattr(self.source, 'final_video_tee').parent

--- a/brave/overlays/overlay.py
+++ b/brave/overlays/overlay.py
@@ -15,7 +15,7 @@ class Overlay(InputOutputOverlay):
 
         super().__init__(**args)
         self._set_source(source_uid)
-        self.visible = self.props['visible']
+        self.visible = self.visible
 
     def input_output_overlay_or_mixer(self):
         return 'overlay'
@@ -35,6 +35,15 @@ class Overlay(InputOutputOverlay):
         if 'source' in updates and self.source != updates['source']:
             self._set_source(updates['source'])
             self.report_update_to_user()
+            del updates['source']
+
+        if 'visible' in updates:
+            if not self.visible and updates['visible']:
+                self.logger.debug('Becoming visible')
+                self._make_visible()
+            if self.visible and not updates['visible']:
+                self.logger.debug('Becoming invisible')
+                self._make_invisible()
 
         return super().update(updates)
 
@@ -74,12 +83,6 @@ class Overlay(InputOutputOverlay):
         if self.source is None:
             return
         self.set_element_values_from_props()
-        if not self.props['visible'] and self.visible:
-            self.logger.debug('Becoming invisible')
-            self._make_invisible()
-        if self.props['visible'] and not self.visible:
-            self.logger.debug('Becoming visible')
-            self._make_visible()
 
     def set_element_values_from_props(self):
         pass

--- a/brave/overlays/text.py
+++ b/brave/overlays/text.py
@@ -34,8 +34,8 @@ class TextOverlay(Overlay):
         self.set_element_values_from_props()
 
     def set_element_values_from_props(self):
-        self.element.set_property('text', self.props['text'])
-        self.element.set_property('valignment', self.props['valignment'])
+        self.element.set_property('text', self.text)
+        self.element.set_property('valignment', self.valignment)
         self.element.set_property('halignment', 'left')
         self.element.set_property('font-desc', 'Sans, 44')
         self.element.set_property('shaded-background', True)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,4 +1,4 @@
-##
+#  ##
 ## Video, audio, or both? Default is both
 ##
 enable_video: true
@@ -17,21 +17,17 @@ default_mixer_height: 360
 ##
 default_inputs:
     # - type: uri
-    #   props:
-    #       zorder: 2
-    #       uri: file:///path/to/file.mp4
-    #       width: 640
-    #       height: 360
+    #   zorder: 2
+    #   uri: file:///path/to/file.mp4
+    #   width: 640
+    #   height: 360
     # - type: image
-    #   props:
-    #       uri: https://upload.wikimedia.org/wikipedia/commons/e/eb/BBC.svg
+    #   uri: https://upload.wikimedia.org/wikipedia/commons/e/eb/BBC.svg
     # - type: test_audio
-    #   props:
-    #       freq: 200
+    #   freq: 200
     # - type: test_video
-    #   props:
-    #       zorder: 3
-    #       pattern: 18
+    #   zorder: 3
+    #   pattern: 18
 
 ##
 ## DEFAULT OUTPUTS
@@ -41,13 +37,11 @@ default_inputs:
 default_outputs:
     # - type: local
     # - type: file
-    #   props:
-    #     location: /path/to/file.mp4
+    #   location: /path/to/file.mp4
     # - type: image
     # - type: tcp
     # - type: rtmp
-    #   props:
-    #       uri: rtmp://domain/path/name
+    #   uri: rtmp://domain/path/name
 
 ##
 ## DEFAULT OVERLAYS
@@ -55,16 +49,13 @@ default_outputs:
 ##
 default_overlays:
     # - type: text
-    #   props:
-    #       text: 'I am some text'
-    #       visible: true
+    #   text: 'I am some text'
+    #   visible: true
     # - type: clock
-    #   props:
-    #       valignment: 'top'
-    #       visible: true
+    #   valignment: 'top'
+    #   visible: true
     # - type: effect
-    #   props:
-    #       effect_name: 'warptv'
+    #   effect_name: 'warptv'
     #       visible: true
 
 ##
@@ -74,4 +65,4 @@ default_overlays:
 ##
 default_mixers:
     # Default to one mixer, with no specific props:
-    - props:
+    - {}

--- a/public/js/components.js
+++ b/public/js/components.js
@@ -53,26 +53,26 @@ components.stateIcon = (state, currentState, linkClassName) => {
 }
 
 components.openCards = {}
-components.card = (props) => {
+components.card = (block) => {
     var card = $('<div class="block-card"></div>')
     var header = $('<div class="block-card-head"></div>')
-    if (props.title) header.append(props.title)
-    if (props.options) {
+    if (block.title) header.append(block.title)
+    if (block.options) {
         var options = $('<div class="option-icons"></div>')
-        options.append(props.options)
+        options.append(block.options)
         header.append(options)
     }
     card.append(header)
-    if (props.state) card.append(props.state)
-    if (props.mixOptions) card.append(props.mixOptions)
+    if (block.state) card.append(block.state)
+    if (block.mixOptions) card.append(block.mixOptions)
 
     const cardBody = $('<div class="block-card-body"></div>')
-    cardBody.append(props.body)
-    if (!components.openCards[props.title]) cardBody.css('display', 'none')
+    cardBody.append(block.body)
+    if (!components.openCards[block.title]) cardBody.css('display', 'none')
 
-    const setToggleMsg = (target) => { target.html(components.openCards[props.title] ? components.hideDetails() : components.showDetails()) }
+    const setToggleMsg = (target) => { target.html(components.openCards[block.title] ? components.hideDetails() : components.showDetails()) }
     const toggleSwitch = $('<a href="#">Toggle</a>').click((change) => {
-        cardBody.toggle(components.openCards[props.title] = !components.openCards[props.title])
+        cardBody.toggle(components.openCards[block.title] = !components.openCards[block.title])
         setToggleMsg($(change.target))
         return false
     })

--- a/public/js/inputs.js
+++ b/public/js/inputs.js
@@ -49,21 +49,21 @@ inputsHandler._optionButtonsForInput = (input) => {
 
 inputsHandler._inputCardBody = (input) => {
     var details = []
-    if (input.props.uri) details.push('<div><code>' + input.props.uri + '</code></div>')
+    if (input.uri) details.push('<div><code>' + input.uri + '</code></div>')
     if (input.hasOwnProperty('width') &&
         input.hasOwnProperty('height')) details.push('<strong>Input size:</strong> ' + prettyDimensions(input))
-    if (input.props.hasOwnProperty('width') &&
-        input.props.hasOwnProperty('height')) details.push('<div><strong>Resized to:</strong> ' + prettyDimensions(input.props) + '</div>')
+    if (input.hasOwnProperty('width') &&
+        input.hasOwnProperty('height')) details.push('<div><strong>Resized to:</strong> ' + prettyDimensions(input) + '</div>')
     if (input.hasOwnProperty('framerate')) details.push('<div><strong>Framerate:</strong> ' + Math.round(input.framerate) + '</div>')
-    if (input.props.hasOwnProperty('xpos') && input.props.hasOwnProperty('ypos')) details.push('<div><strong>Position on screen:</strong> ' + input.props.xpos + 'x' + input.props.ypos + '</div>')
-    if (input.props.hasOwnProperty('zorder')) details.push('<strong>Z-order:</strong> ' + input.props.zorder)
+    if (input.hasOwnProperty('xpos') && input.hasOwnProperty('ypos')) details.push('<div><strong>Position on screen:</strong> ' + input.xpos + 'x' + input.ypos + '</div>')
+    if (input.hasOwnProperty('zorder')) details.push('<strong>Z-order:</strong> ' + input.zorder)
     if (input.hasOwnProperty('audio_channels')) details.push('<div><strong>Audio channels:</strong> ' + input.audio_channels + '</div>')
     if (input.hasOwnProperty('audio_rate')) details.push('<div><strong>Audio rate:</strong> ' + input.audio_rate + '</div>')
-    if (input.props.hasOwnProperty('volume')) details.push('<div><strong>Volume:</strong> ' + (100 * input.props.volume) + '&#37;</div>')
-    if (input.props.hasOwnProperty('input_volume')) details.push('<div><strong>Input volume:</strong> ' + input.props.input_volume + '</div>')
-    if (input.props.hasOwnProperty('freq')) details.push('<div><strong>Frequency:</strong> ' + input.props.freq + 'Hz</div>')
-    if (input.props.hasOwnProperty('pattern')) details.push('<div><strong>Pattern:</strong> ' + inputsHandler.patternTypes[input.props.pattern] + '</div>')
-    if (input.props.hasOwnProperty('wave')) details.push('<div><strong>Wave:</strong> ' + inputsHandler.waveTypes[input.props.wave] + '</div>')
+    if (input.hasOwnProperty('volume')) details.push('<div><strong>Volume:</strong> ' + (100 * input.volume) + '&#37;</div>')
+    if (input.hasOwnProperty('input_volume')) details.push('<div><strong>Input volume:</strong> ' + input.input_volume + '</div>')
+    if (input.hasOwnProperty('freq')) details.push('<div><strong>Frequency:</strong> ' + input.freq + 'Hz</div>')
+    if (input.hasOwnProperty('pattern')) details.push('<div><strong>Pattern:</strong> ' + inputsHandler.patternTypes[input.pattern] + '</div>')
+    if (input.hasOwnProperty('wave')) details.push('<div><strong>Wave:</strong> ' + inputsHandler.waveTypes[input.wave] + '</div>')
 
     if (input.hasOwnProperty('duration')) {
         var duration = prettyDuration(input.duration)
@@ -88,7 +88,6 @@ inputsHandler._showForm = function(input) {
 inputsHandler._populateForm = function(input) {
     var form = inputsHandler.currentForm
     form.empty()
-    if (!input.props) input.props = {}
 
     var uriExamples = ''
     if (input.type && input.type === 'uri') {
@@ -105,7 +104,7 @@ inputsHandler._populateForm = function(input) {
         label: 'Position (&lt;width&gt;x&lt;height&gt;)',
         name: 'position',
         type: 'text',
-        value: (input.props.xpos || 0) + 'x' + (input.props.ypos || 0),
+        value: (input.xpos || 0) + 'x' + (input.ypos || 0),
         help: 'In the format <samp>&lt;width&gt;x&lt;height&gt;</samp>. The default, <samp>0x0</samp>, puts it in the top-left corner.'
     })
 
@@ -114,7 +113,7 @@ inputsHandler._populateForm = function(input) {
         label: 'Z-order',
         name: 'zorder',
         type: 'number',
-        value: input.props.zorder || inputsHandler.getNextZorder()
+        value: input.zorder || inputsHandler.getNextZorder()
     })
 
     var uriRow = formGroup({
@@ -122,11 +121,11 @@ inputsHandler._populateForm = function(input) {
         label: 'Location (URI)',
         name: 'uri',
         type: 'text',
-        value: input.props.uri || '',
+        value: input.uri || '',
         help: uriExamples,
     })
 
-    var sizeBox = getDimensionsSelect('dimensions', input.props.width, input.props.height)
+    const sizeBox = getDimensionsSelect('dimensions', input.width, input.height)
 
     var patternBox = formGroup({
         id: 'input-pattern',
@@ -134,7 +133,7 @@ inputsHandler._populateForm = function(input) {
         name: 'pattern',
         options: inputsHandler.patternTypes,
         initialOption: 'Select a pattern...',
-        value: input.props.pattern || inputsHandler.patternTypes[0]
+        value: input.pattern || inputsHandler.patternTypes[0]
     })
 
     var waveBox = formGroup({
@@ -143,7 +142,7 @@ inputsHandler._populateForm = function(input) {
         name: 'wave',
         options: inputsHandler.waveTypes,
         initialOption: 'Select a wave...',
-        value: input.props.wave || inputsHandler.waveTypes[0]
+        value: input.wave || inputsHandler.waveTypes[0]
     })
 
     var freqBox = formGroup({
@@ -151,7 +150,7 @@ inputsHandler._populateForm = function(input) {
         label: 'Frequency (Hz)',
         name: 'freq',
         type: 'number',
-        value: input.props.freq || 440,
+        value: input.freq || 440,
         min: 20,
         step: 100,
         max: 20000
@@ -183,7 +182,7 @@ inputsHandler._populateForm = function(input) {
     }
     else if (input.type === 'test_audio') {
         form.append();
-        form.append(components.volumeInput(input.props.volume));
+        form.append(components.volumeInput(input.volume));
         form.append(waveBox);
         form.append(freqBox);
     }
@@ -204,7 +203,7 @@ inputsHandler._populateForm = function(input) {
         form.append(positionBox);
         form.append(sizeBox);
         form.append(zOrderBox);
-        form.append(components.volumeInput(input.props.volume));
+        form.append(components.volumeInput(input.volume));
     }
     else if (input.type === 'html') {
         if (isNew) form.append(uriRow);
@@ -220,8 +219,9 @@ inputsHandler._handleFormSubmit = function() {
     var form = inputsHandler.currentForm
     var idField = form.find('input[name="id"]')
     var id = idField.length ? idField.val() : null
-    var input = (id != null) ? inputsHandler.findById(id) : {}
-    var newProps = {}
+    const isNew = id == null
+    const input = isNew ? {} : inputsHandler.findById(id)
+    const newProps = {}
 
     fields = ['type', 'uri', 'position', 'zorder', 'dimensions', 'freq', 'volume', 'input_volume', 'pattern', 'wave']
     fields.forEach(function(f) {
@@ -231,7 +231,7 @@ inputsHandler._handleFormSubmit = function() {
         }
     })
 
-    if (newProps['volume']) newProps['volume'] /= 100 // convert percentage
+    if (newProps.volume) newProps.volume /= 100 // convert percentage
 
     splitDimensionsIntoWidthAndHeight(newProps)
     splitPositionIntoXposAndYpos(newProps)
@@ -248,30 +248,20 @@ inputsHandler._handleFormSubmit = function() {
         return
     }
 
-    if (type === 'uri') {
-        var uri = newProps.uri || (input.props && input.props.uri)
-        good_uri_regexp = '^(file|rtp|rtsp|rtmp|http|https)://'
-        if (!uri || !uri.match(good_uri_regexp)) {
-            showMessage('uri must start with ' + good_uri_regexp, 'info')
-            return
-        }
+    const GOOD_URI_REGEXP = {
+        'uri': '^(file|rtp|rtsp|rtmp|http|https)://',
+        'image': '^(file||http|https)://',
+        'html': '^(file||http|https)://'
     }
 
-    if (type === 'image') {
-        var uri = newProps.uri || (input.props && input.props.uri)
-        good_uri_regexp = '^(file||http|https)://'
-        if (!uri || !uri.match(good_uri_regexp)) {
-            showMessage('Image uri must start with ' + good_uri_regexp, 'info')
-            return
+    if (GOOD_URI_REGEXP[type]) {
+        if (newProps.uri) {
+            if (!newProps.uri.match(GOOD_URI_REGEXP[type])) {
+                showMessage('uri must start with ' + good_uri_regexp, 'info')
+            }
         }
-    }
-
-    if (type === 'html') {
-        var uri = newProps.uri || (input.props && input.props.uri)
-        good_uri_regexp = '^(file||http|https)://'
-        if (!uri || !uri.match(good_uri_regexp)) {
-            showMessage('HTML layer must start with ' + good_uri_regexp, 'info')
-            return
+        else if (isNew) {
+            showMessage('URI field is required', 'info')
         }
     }
 
@@ -280,8 +270,7 @@ inputsHandler._handleFormSubmit = function() {
         return
     }
 
-    delete newProps.type
-    inputsHandler._submitCreateOrEdit(input.id, {type: type, props: newProps})
+    inputsHandler._submitCreateOrEdit(id, newProps)
     hideModal();
 }
 
@@ -379,7 +368,7 @@ function prettyDuration(d) {
 inputsHandler.getNextZorder = function() {
     maxZorder = 1
     inputsHandler.items.forEach(i =>{
-        if (i.props && i.props.zorder && i.props.zorder >= maxZorder) maxZorder = i.props.zorder + 1
+        if (i.zorder && i.zorder >= maxZorder) maxZorder = i.zorder + 1
     })
     return maxZorder
 }

--- a/public/js/mixers.js
+++ b/public/js/mixers.js
@@ -55,9 +55,9 @@ mixersHandler._optionButtonsForMixer = (mixer) => {
 
 mixersHandler._mixerCardBody = (mixer) => {
     var details = []
-    if (mixer.props.hasOwnProperty('pattern')) details.push('<div><strong>Background:</strong> ' + inputsHandler.patternTypes[mixer.props.pattern] + '</div>')
-    if (mixer.props.hasOwnProperty('width') &&
-        mixer.props.hasOwnProperty('height')) details.push('<div><strong>Dimension:</strong> ' + prettyDimensions(mixer.props) + '</div>')
+    if (mixer.hasOwnProperty('pattern')) details.push('<div><strong>Background:</strong> ' + inputsHandler.patternTypes[mixer.pattern] + '</div>')
+    if (mixer.hasOwnProperty('width') &&
+        mixer.hasOwnProperty('height')) details.push('<div><strong>Dimension:</strong> ' + prettyDimensions(mixer) + '</div>')
     return details
 }
 
@@ -88,13 +88,11 @@ mixersHandler._populateForm = function(mixer) {
     var form = mixersHandler.currentForm
     form.empty()
 
-    if (!mixer.props) mixer.props = {}
-
     if (mixer.hasOwnProperty('id')) {
         form.append('<input type="hidden" name="id" value="' + mixer.id + '">')
     }
 
-    form.append(getDimensionsSelect('dimensions', mixer.props.width, mixer.props.height))
+    form.append(getDimensionsSelect('dimensions', mixer.width, mixer.height))
 
     form.append(formGroup({
         id: 'mixer-pattern',
@@ -102,7 +100,7 @@ mixersHandler._populateForm = function(mixer) {
         name: 'pattern',
         options: inputsHandler.patternTypes,
         initialOption: 'Select a pattern...',
-        value: mixer.props.pattern
+        value: mixer.pattern
     }))
 }
 
@@ -122,7 +120,7 @@ mixersHandler._handleFormSubmit = function() {
     })
     splitDimensionsIntoWidthAndHeight(newProps)
     console.log('Submitting new mixer with values', newProps)
-    mixersHandler._submitCreateOrEdit(id, {props: newProps})
+    mixersHandler._submitCreateOrEdit(id, newProps)
     hideModal();
 }
 

--- a/public/js/outputs.js
+++ b/public/js/outputs.js
@@ -53,29 +53,29 @@ outputsHandler._outputCardBody = (output) => {
     if (output.current_num_peers) {
         details.push('<strong>Number of connections:</strong> ' + output.current_num_peers)
     }
-    if (output.props.location) {
-        details.push('<strong>Location:</strong> ' + output.props.location)
+    if (output.location) {
+        details.push('<strong>Location:</strong> ' + output.location)
     }
-    else if (output.props.uri) {
-        details.push('<strong>URI:</strong> <code>' + output.props.uri + '</code></div>')
+    else if (output.uri) {
+        details.push('<strong>URI:</strong> <code>' + output.uri + '</code></div>')
     }
-    else if (output.props.host && output.props.port && output.type === 'tcp') {
+    else if (output.host && output.port && output.type === 'tcp') {
         current_domain = $('<a>').attr('href', document.location.href).prop('hostname');
-        host = current_domain === '127.0.0.1' ? output.props.host : current_domain
-        // Instead of domain we can use output.props.host but it may be an internal (private) IP
-        details.push('<strong>URI:</strong> <code>tcp://' + host + ':' + output.props.port + '</code> (Use VLC to watch this)')
-        details.push('<strong>Container:</strong> <code>' + output.props.container + '</code>')
+        host = current_domain === '127.0.0.1' ? output.host : current_domain
+        // Instead of domain we can use output.host but it may be an internal (private) IP
+        details.push('<strong>URI:</strong> <code>tcp://' + host + ':' + output.port + '</code> (Use VLC to watch this)')
+        details.push('<strong>Container:</strong> <code>' + output.container + '</code>')
     }
 
-    if (output.props.hasOwnProperty('width') &&
-        output.props.hasOwnProperty('height')) details.push('<strong>Output size:</strong> ' + prettyDimensions(output.props))
+    if (output.hasOwnProperty('width') &&
+        output.hasOwnProperty('height')) details.push('<strong>Output size:</strong> ' + prettyDimensions(output))
 
-    if (output.props.audio_bitrate) {
-        details.push('<strong>Audio bitrate:</strong> ' + output.props.audio_bitrate)
+    if (output.audio_bitrate) {
+        details.push('<strong>Audio bitrate:</strong> ' + output.audio_bitrate)
     }
 
-    if (output.props.hasOwnProperty('stream_name')) {
-        details.push('<strong>Stream name:</strong> ' + output.props.stream_name)
+    if (output.hasOwnProperty('stream_name')) {
+        details.push('<strong>Stream name:</strong> ' + output.stream_name)
     }
 
     if (output.hasOwnProperty('source')) {
@@ -132,7 +132,6 @@ outputsHandler._showForm = function(output) {
 outputsHandler._populateForm = function(output) {
     var form = outputsHandler.currentForm
     form.empty()
-    if (!output.props) output.props = {}
     var isNew = !output.hasOwnProperty('id')
     if (isNew) {
         form.append(outputsHandler._getOutputsSelect(output))
@@ -160,14 +159,14 @@ outputsHandler._populateForm = function(output) {
             label: 'Audio bitrate',
             name: 'audio_bitrate',
             type: 'number',
-            value: output.props.audio_bitrate || '',
+            value: output.audio_bitrate || '',
             help: 'Leave blank for default (128000)',
             min: 1000,
             step: 1000,
             max: 128000*16
         }))
 
-        form.append(getDimensionsSelect('dimensions', output.props.width, output.props.height))
+        form.append(getDimensionsSelect('dimensions', output.width, output.height))
     }
     else if (output.type === 'rtmp') {
         form.append(formGroup({
@@ -259,7 +258,7 @@ outputsHandler._handleFormSubmit = function() {
     }
 
     if (type === 'rtmp') {
-        var uri = newProps.uri || output.uri
+        const uri = newuri || output.uri
         good_uri_regexp = '^rtmp(s?)://'
         if (!uri || !uri.match(good_uri_regexp)) {
             showMessage('uri must start with ' + good_uri_regexp)
@@ -272,10 +271,8 @@ outputsHandler._handleFormSubmit = function() {
         return
     }
 
-    delete newProps.type
-    const source = newProps.source === 'none' ? null : newProps.source
-    delete newProps.source
-    outputsHandler._submitCreateOrEdit(output.id, {type, source, props: newProps}, outputsHandler._onNewOutputSuccess)
+    if (newProps.source === 'none') newProps.source = null
+    outputsHandler._submitCreateOrEdit(output.id, newProps, outputsHandler._onNewOutputSuccess)
     hideModal();
 }
 

--- a/public/js/overlays.js
+++ b/public/js/overlays.js
@@ -42,18 +42,19 @@ overlaysHandler._optionButtonsForOverlay  = (overlay) => {
 }
 
 overlaysHandler._overlayCardBody = (overlay) => {
-    return Object.keys(overlay.props).map(propName =>
-        $('<div></div>')
-        .append('<strong>' + propName + ':</strong> ' + overlay.props[propName])
-    )
+    const details = []
+    if (overlay.effect_name) details.push('<strong>Effect:</strong> ' + overlay.effect_name)
+    if (overlay.text) details.push('<strong>Text:</strong> ' + overlay.text)
+    if (overlay.valignment) details.push('<strong>Vertical alignment:</strong> ' + overlay.valignment)
+    return details.map(d => $('<div></div>').append(d))
 }
 
 overlaysHandler.overlay = (overlay) => {
-    overlaysHandler._submitCreateOrEdit(overlay.id, { props: { visible: true }})
+    overlaysHandler._submitCreateOrEdit(overlay.id, {visible: true})
 }
 
 overlaysHandler.remove = (overlay) => {
-    overlaysHandler._submitCreateOrEdit(overlay.id, { props: { visible: false }})
+    overlaysHandler._submitCreateOrEdit(overlay.id, {visible: false})
 }
 
 overlaysHandler._getMixOptions = (overlay) => {
@@ -63,7 +64,7 @@ overlaysHandler._getMixOptions = (overlay) => {
         return div.append('Not connected')
     }
     var showingOrHidden
-    if (overlay.props.visible) {
+    if (overlay.visible) {
         showingOrHidden = 'In mix'
         div.addClass('mix-option-showing')
         var removeButton = components.removeButton()
@@ -115,8 +116,6 @@ overlaysHandler._populateForm = function(overlay) {
     var form = overlaysHandler.currentForm
     form.empty()
 
-    if (!overlay.props) overlay.props = {}
-
     var isNew = !overlay.hasOwnProperty('id')
     if (isNew) {
         options = {
@@ -145,7 +144,7 @@ overlaysHandler._populateForm = function(overlay) {
             id: 'overlay-text',
             label: 'Text',
             name: 'text',
-            value: overlay.props.text || '',
+            value: overlay.text || '',
             help: 'The text to be shown by this overlay'
         }))
         form.append(formGroup({
@@ -154,7 +153,7 @@ overlaysHandler._populateForm = function(overlay) {
             name: 'valignment',
             initialOption: 'Select an alignment...',
             options: overlaysHandler.valignmentTypes,
-            value: overlay.props && overlay.props.valignment ? overlay.props.valignment : 'bottom'
+            value: overlay && overlay.valignment ? overlay.valignment : 'bottom'
         }))
     }
     else if (overlay.type === 'effect') {
@@ -164,7 +163,7 @@ overlaysHandler._populateForm = function(overlay) {
             name: 'effect_name',
             initialOption: 'Select an effect...',
             options: overlaysHandler.effectNames,
-            value: overlay.props ? overlay.props.effect_name : undefined
+            value: overlay ? overlay.effect_name : undefined
         }))
     }
 
@@ -212,11 +211,9 @@ overlaysHandler._handleFormSubmit = function() {
         return
     }
 
+    if (newProps.source === 'none') newProps.source = null
     console.log('Submitting new overlay with values', newProps)
-    delete newProps.type
-    const source = newProps.source === 'none' ? null : newProps.source
-    delete newProps.source
-    overlaysHandler._submitCreateOrEdit(id, {type, source, props: newProps})
+    overlaysHandler._submitCreateOrEdit(id, newProps)
     hideModal();
 }
 

--- a/tests/test_add_and_remove_from_mix.py
+++ b/tests/test_add_and_remove_from_mix.py
@@ -43,8 +43,8 @@ def set_up_two_sources(run_brave, create_config_file):
 
     config = {
     'default_inputs': [
-        {'type': 'test_video', 'props': {'pattern': 4, 'zorder': 2}}, # pattern 4 is red
-        {'type': 'test_video', 'props': {'pattern': 5, 'zorder': 3}}, # pattern 5 is green
+        {'type': 'test_video', 'pattern': 4, 'zorder': 2}, # pattern 4 is red
+        {'type': 'test_video', 'pattern': 5, 'zorder': 3}, # pattern 5 is green
     ],
     'default_mixers': [
         {

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -27,15 +27,15 @@ def test_brave_with_full_config_file(run_brave, create_config_file):
     config = {
     'default_inputs': [
         {'type': 'test_video'},
-        {'type': 'test_audio', 'props': { 'freq': 200 } },
-        {'type': 'test_audio', 'props': { 'freq': 600 } },
-        {'type': 'uri', 'props': { 'uri': 'file://' + file_asset } }
+        {'type': 'test_audio',  'freq': 200 } ,
+        {'type': 'test_audio',  'freq': 600 } ,
+        {'type': 'uri',  'uri': 'file://' + file_asset }
     ],
     'default_outputs': [
         {'type': 'local', 'source': 'input4'},
         {'type': 'tcp'},
-        {'type': 'file', 'source': 'input1', 'props': { 'location': output_video_location}},
-        {'type': 'image', 'source': 'input2', 'props': { 'location': output_image_location}}
+        {'type': 'file', 'source': 'input1',  'location': output_video_location},
+        {'type': 'image', 'source': 'input2',  'location': output_image_location}
     ]
     }
     config_file = create_config_file(config)
@@ -48,12 +48,12 @@ def test_brave_with_full_config_file(run_brave, create_config_file):
     assert response.json()['inputs'][0]['type'] == 'test_video'
     assert response.json()['inputs'][1]['type'] == 'test_audio'
     assert response.json()['inputs'][2]['type'] == 'test_audio'
-    assert response.json()['inputs'][1]['props']['freq'] == 200
-    assert response.json()['inputs'][2]['props']['freq'] == 600
+    assert response.json()['inputs'][1]['freq'] == 200
+    assert response.json()['inputs'][2]['freq'] == 600
     assert response.json()['outputs'][0]['type'] == 'local'
     assert response.json()['outputs'][1]['type'] == 'tcp'
     assert response.json()['outputs'][2]['type'] == 'file'
     assert response.json()['outputs'][3]['type'] == 'image'
-    assert response.json()['outputs'][2]['props']['location'] == output_video_location
+    assert response.json()['outputs'][2]['location'] == output_video_location
     assert response.json()['outputs'][2]['source'] == 'input1'
     assert response.json()['outputs'][3]['source'] == 'input2'

--- a/tests/test_effect_overlay.py
+++ b/tests/test_effect_overlay.py
@@ -8,27 +8,27 @@ def test_effect_overlay_visible_after_creation(run_brave):
     time.sleep(0.5)
     check_brave_is_running()
 
-    add_overlay({'type': 'effect', 'source': 'mixer1', 'props': {'effect_name': 'edgetv'}})
+    add_overlay({'type': 'effect', 'source': 'mixer1', 'effect_name': 'edgetv'})
     time.sleep(0.1)
-    assert_overlays([{'id': 1, 'props': {'visible': False, 'effect_name': 'edgetv'}}])
+    assert_overlays([{'id': 1, 'visible': False, 'effect_name': 'edgetv'}])
 
-    update_overlay(1, {'props': {'visible': True}}, status_code=200)
+    update_overlay(1, {'visible': True}, status_code=200)
     time.sleep(0.1)
-    assert_overlays([{'id': 1, 'props': {'visible': True,'effect_name': 'edgetv'}}])
+    assert_overlays([{'id': 1, 'visible': True,'effect_name': 'edgetv'}])
 
-    add_overlay({'type': 'effect', 'source': 'mixer1',  'props': {'effect_name': 'solarize'}})
+    add_overlay({'type': 'effect', 'source': 'mixer1',  'effect_name': 'solarize'})
     time.sleep(0.1)
-    assert_overlays([{'id': 1, 'props': {'visible': True,'effect_name': 'edgetv'}},
-                     {'id': 2, 'props': {'visible': False, 'effect_name': 'solarize'}}])
+    assert_overlays([{'id': 1, 'visible': True,'effect_name': 'edgetv'},
+                     {'id': 2, 'visible': False, 'effect_name': 'solarize'}])
 
-    update_overlay(2, {'props': {'visible': True}}, status_code=200)
+    update_overlay(2, {'visible': True}, status_code=200)
     time.sleep(0.1)
-    assert_overlays([{'id': 1, 'props': {'visible': True,'effect_name': 'edgetv'}},
-                     {'id': 2, 'props': {'visible': True,'effect_name': 'solarize'}}])
+    assert_overlays([{'id': 1, 'visible': True,'effect_name': 'edgetv'},
+                     {'id': 2, 'visible': True,'effect_name': 'solarize'}])
 
     delete_overlay(1)
     time.sleep(0.1)
-    assert_overlays([{'id': 2, 'props': {'visible': True,'effect_name': 'solarize'}}])
+    assert_overlays([{'id': 2, 'visible': True,'effect_name': 'solarize'}])
 
     delete_overlay(2)
     time.sleep(0.1)
@@ -42,9 +42,9 @@ def test_effect_overlay_visible_at_creation(run_brave):
     check_brave_is_running()
 
     # This time, visible from the start with visible=True
-    add_overlay({'type': 'effect', 'source': 'mixer1',  'props': {'effect_name': 'warptv', 'visible': True}}, status_code=200)
+    add_overlay({'type': 'effect', 'source': 'mixer1',  'effect_name': 'warptv', 'visible': True}, status_code=200)
     time.sleep(0.1)
-    assert_overlays([{'props': {'visible': True, 'effect_name': 'warptv'}}])
+    assert_overlays([{'visible': True, 'effect_name': 'warptv'}])
 
 
 def test_set_up_effect_overlay_in_config_file(run_brave, create_config_file):
@@ -54,13 +54,13 @@ def test_set_up_effect_overlay_in_config_file(run_brave, create_config_file):
     config = {
     'default_mixers': [{}],
     'default_overlays': [
-        {'type': 'effect', 'source': 'mixer1', 'props': {'effect_name': 'burn', 'visible': True}},
-        {'type': 'effect', 'source': 'mixer1', 'props': {'effect_name': 'vertigotv', 'visible': False}}
+        {'type': 'effect', 'source': 'mixer1', 'effect_name': 'burn', 'visible': True},
+        {'type': 'effect', 'source': 'mixer1', 'effect_name': 'vertigotv', 'visible': False}
     ]
     }
     config_file = create_config_file(config)
     run_brave(config_file.name)
     time.sleep(0.5)
     check_brave_is_running()
-    assert_overlays([{'id': 1, 'props': {'effect_name': 'burn', 'visible': True}},
-                     {'id': 2, 'props': {'effect_name': 'vertigotv', 'visible': False}}])
+    assert_overlays([{'id': 1, 'effect_name': 'burn', 'visible': True},
+                     {'id': 2, 'effect_name': 'vertigotv', 'visible': False}])

--- a/tests/test_elements_api_endpoint.py
+++ b/tests/test_elements_api_endpoint.py
@@ -10,7 +10,7 @@ def test_elements_api_endpoint(run_brave):
     run_brave()
     time.sleep(0.5)
     check_brave_is_running()
-    add_input({'type': 'image', 'props': {'uri': 'file://' + test_directory() + '/assets/image_640_360.png'}})
+    add_input({'type': 'image', 'uri': 'file://' + test_directory() + '/assets/image_640_360.png'})
     cut_to_source('input1', 1)
     time.sleep(0.5)
 

--- a/tests/test_file_output.py
+++ b/tests/test_file_output.py
@@ -7,10 +7,10 @@ def test_can_create_video_file_output(run_brave, create_config_file):
 
     config = {
     'default_inputs': [
-        {'type': 'test_video', 'props': {'pattern': 4, 'zorder': 2}}, # pattern 4 is red
+        {'type': 'test_video', 'pattern': 4, 'zorder': 2}, # pattern 4 is red
     ],
     'default_outputs': [
-        {'type': 'file', 'props': { 'location': output_video_location } }
+        {'type': 'file',  'location': output_video_location } 
         # ,{'type': 'local'} # good for debugging
     ]
     }

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -7,8 +7,8 @@ def test_image_input_from_command_line(run_brave, create_config_file):
     config = {
         'enable_audio': False, # useful for debugging TODO remove
         'default_inputs': [
-            # {'type': 'test_video', 'props': {'pattern': 4, 'zorder': 2}}, # pattern 4 is red
-            {'type': 'image', 'props': {'uri': image_uri}}, # pattern 4 is red
+            # {'type': 'test_video', 'pattern': 4, 'zorder': 2}, # pattern 4 is red
+            {'type': 'image', 'uri': image_uri}, # pattern 4 is red
         ],
         'default_outputs': [
             {'type': 'local'} # good for debugging

--- a/tests/test_image_output.py
+++ b/tests/test_image_output.py
@@ -8,11 +8,11 @@ def test_image_output(run_brave, create_config_file):
     config = {
     'default_mixers': [{'sources': {'input1': {}}}],
     'default_inputs': [
-        {'type': 'test_video', 'props': {'pattern': 4, 'zorder': 2}}, # pattern 4 is red
+        {'type': 'test_video', 'pattern': 4, 'zorder': 2}, # pattern 4 is red
     ],
     'default_outputs': [
         {'type': 'local'}, # good for debugging
-        {'type': 'image', 'props': { 'location': output_image_location } }
+        {'type': 'image',  'location': output_image_location } 
     ]
     }
     config_file = create_config_file(config)

--- a/tests/test_initial_state.py
+++ b/tests/test_initial_state.py
@@ -12,22 +12,22 @@ def test_initial_state_option_on_startup(run_brave, create_config_file):
 
     config = {
     'default_inputs': [
-        {'type': 'test_video', 'props': {'pattern': 4, 'initial_state': 'PLAYING'}},
-        {'type': 'test_video', 'props': {'pattern': 5, 'initial_state': 'PAUSED'}},
-        {'type': 'test_video', 'props': {'pattern': 6, 'initial_state': 'READY'}},
-        {'type': 'test_video', 'props': {'pattern': 7, 'initial_state': 'NULL'}},
+        {'type': 'test_video', 'pattern': 4, 'initial_state': 'PLAYING'},
+        {'type': 'test_video', 'pattern': 5, 'initial_state': 'PAUSED'},
+        {'type': 'test_video', 'pattern': 6, 'initial_state': 'READY'},
+        {'type': 'test_video', 'pattern': 7, 'initial_state': 'NULL'},
     ],
     'default_mixers': [
-        {'props': {'initial_state': 'PLAYING'}},
-        {'props': {'initial_state': 'PAUSED'}},
-        {'props': {'initial_state': 'READY'}},
-        {'props': {'initial_state': 'NULL'}},
+        {'initial_state': 'PLAYING'},
+        {'initial_state': 'PAUSED'},
+        {'initial_state': 'READY'},
+        {'initial_state': 'NULL'},
     ],
     'default_outputs': [
-        {'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'PLAYING'}},
-        {'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'PAUSED'}},
-        {'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'READY'}},
-        {'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'NULL'}},
+        {'type': 'image', 'location': output_image_location0, 'initial_state': 'PLAYING'},
+        {'type': 'image', 'location': output_image_location0, 'initial_state': 'PAUSED'},
+        {'type': 'image', 'location': output_image_location0, 'initial_state': 'READY'},
+        {'type': 'image', 'location': output_image_location0, 'initial_state': 'NULL'},
     ]
     }
     config_file = create_config_file(config)
@@ -63,20 +63,20 @@ def test_initial_state_option_via_api(run_brave):
     assert_everything_in_playing_state(response.json())
     output_image_location0 = create_output_image_location()
 
-    add_input({'type': 'test_audio', 'props': {'initial_state': 'NULL'}})
-    add_input({'type': 'test_audio', 'props': {'initial_state': 'READY'}})
-    add_input({'type': 'test_audio', 'props': {'initial_state': 'PAUSED'}})
-    add_input({'type': 'test_audio', 'props': {'initial_state': 'PLAYING'}})
+    add_input({'type': 'test_audio', 'initial_state': 'NULL'})
+    add_input({'type': 'test_audio', 'initial_state': 'READY'})
+    add_input({'type': 'test_audio', 'initial_state': 'PAUSED'})
+    add_input({'type': 'test_audio', 'initial_state': 'PLAYING'})
 
-    add_mixer({'props': {'initial_state': 'NULL'}})
-    add_mixer({'props': {'initial_state': 'READY'}})
-    add_mixer({'props': {'initial_state': 'PAUSED'}})
-    add_mixer({'props': {'initial_state': 'PLAYING'}})
+    add_mixer({'initial_state': 'NULL'})
+    add_mixer({'initial_state': 'READY'})
+    add_mixer({'initial_state': 'PAUSED'})
+    add_mixer({'initial_state': 'PLAYING'})
 
-    add_output({'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'NULL'}})
-    add_output({'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'READY'}})
-    add_output({'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'PAUSED'}})
-    add_output({'type': 'image', 'props': {'location': output_image_location0, 'initial_state': 'PLAYING'}})
+    add_output({'type': 'image', 'location': output_image_location0, 'initial_state': 'NULL'})
+    add_output({'type': 'image', 'location': output_image_location0, 'initial_state': 'READY'})
+    add_output({'type': 'image', 'location': output_image_location0, 'initial_state': 'PAUSED'})
+    add_output({'type': 'image', 'location': output_image_location0, 'initial_state': 'PLAYING'})
 
     time.sleep(1)
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -35,15 +35,15 @@ def test_inputs(run_brave):
     assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2}])
 
     # Add a property to existing input
-    update_input(1, {'props': {'pattern': 5}})
-    assert_inputs([{'type': 'test_video', 'id': 1, 'props': {'pattern': 5}}, {'type': 'test_audio', 'id': 2}])
+    update_input(1, {'pattern': 5})
+    assert_inputs([{'type': 'test_video', 'id': 1, 'pattern': 5}, {'type': 'test_audio', 'id': 2}])
 
     # Add a bad property to existing input
-    update_input(2, {'props': {'not_real': 100}}, 400)
+    update_input(2, {'not_real': 100}, 400)
     assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2}])
 
     # Add a property to missing input
-    update_input(55, {'props': {'pattern': 6}}, 400)
+    update_input(55, {'pattern': 6}, 400)
 
     # Removing an existing input works:
     delete_input(1)

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -10,7 +10,7 @@ def test_inputs(run_brave):
     # Create input, ignore attempts to set an ID
     add_input({'type': 'test_video', 'id': 99})
     time.sleep(2)
-    assert_inputs([{'type': 'test_video', 'id': 1}])
+    assert_inputs([{'type': 'test_video', 'id': 1, 'uid': 'input1'}])
 
     # Different types of inputs work:
     add_input({'type': 'test_audio'})

--- a/tests/test_mixer_to_mixer.py
+++ b/tests/test_mixer_to_mixer.py
@@ -28,7 +28,7 @@ def subtest_ensure_mixer2_is_red():
 
 def subtest_start_brave_with_two_mixers(run_brave, create_config_file):
     # Pattern 4 is red and pattern 5 is green
-    config = {'default_mixers': [{'props': {'pattern': 4}}, {'props': {'pattern': 5}}]}
+    config = {'default_mixers': [{'pattern': 4}, {'pattern': 5}]}
     config_file = create_config_file(config)
     run_brave(config_file.name)
     time.sleep(0.5)

--- a/tests/test_mixers.py
+++ b/tests/test_mixers.py
@@ -33,9 +33,11 @@ def subtest_start_brave_with_mixers(run_brave, create_config_file):
 def subtest_assert_two_mixers(mixer_1_props):
     assert_mixers([{
         'id': 1,
+        'uid': 'mixer1',
         **mixer_1_props,
     }, {
         'id': 2,
+        'uid': 'mixer2',
         'width': 640, 'height': 360, 'pattern': 0,
     }])
 

--- a/tests/test_mixers.py
+++ b/tests/test_mixers.py
@@ -23,7 +23,7 @@ def subtest_start_brave_with_mixers(run_brave, create_config_file):
         'width': 640,
         'height': 360
     }
-    config = {'default_mixers': [{'props': MIXER1}, {'props': MIXER2}]}
+    config = {'default_mixers': [MIXER1, MIXER2]}
     config_file = create_config_file(config)
     run_brave(config_file.name)
     time.sleep(1)
@@ -33,18 +33,18 @@ def subtest_start_brave_with_mixers(run_brave, create_config_file):
 def subtest_assert_two_mixers(mixer_1_props):
     assert_mixers([{
         'id': 1,
-        'props': mixer_1_props,
+        **mixer_1_props,
     }, {
         'id': 2,
-        'props': {'width': 640, 'height': 360, 'pattern': 0},
+        'width': 640, 'height': 360, 'pattern': 0,
     }])
 
 def subtest_change_mixer_pattern():
-    update_mixer(1, {'props': {'pattern': 7}})
+    update_mixer(1, {'pattern': 7})
 
 
 def subtest_change_width_and_height():
-    update_mixer(1, {'props': {'width': 200, 'height': 300}})
+    update_mixer(1, {'width': 200, 'height': 300})
 
 
 def subtest_delete_mixers():
@@ -61,11 +61,11 @@ def test_mixer_from_api(run_brave):
     run_brave()
 
     # There is one mixer by default
-    assert_mixers([{'id': 1, 'props': {'width': 640, 'height': 360}}])
+    assert_mixers([{'id': 1, 'width': 640, 'height': 360}])
 
     # Create input, ignore attempts to set an ID
-    add_mixer({'props': {'width': 200, 'height': 200}})
+    add_mixer({'width': 200, 'height': 200})
     time.sleep(1)
-    assert_mixers([{'id': 1, 'props': {'width': 640, 'height': 360}},
-                   {'id': 2, 'props': {'width': 200, 'height': 200}}])
+    assert_mixers([{'id': 1, 'width': 640, 'height': 360},
+                   {'id': 2, 'width': 200, 'height': 200}])
     subtest_delete_mixers()

--- a/tests/test_multiple_inputs_and_mixers.py
+++ b/tests/test_multiple_inputs_and_mixers.py
@@ -18,8 +18,8 @@ MIXER2 = {
 }
 
 # INPUT1 is RED and INPUT2 is GREEN:
-INPUT1 = {'type': 'test_video', 'props': { 'pattern': 4, 'zorder': 10 } }
-INPUT2 = {'type': 'test_video', 'props': { 'pattern': 5, 'zorder': 20 } }
+INPUT1 = {'type': 'test_video',  'pattern': 4, 'zorder': 10 }
+INPUT2 = {'type': 'test_video',  'pattern': 5, 'zorder': 20 }
 OUTPUT1 = {'type': 'image', 'source': 'mixer1'}
 OUTPUT2 = {'type': 'image', 'source': 'mixer2'}
 
@@ -50,7 +50,7 @@ def subtest_ensure_one_mixer_does_not_affect_another():
 
 def subtest_addition_of_input():
     # Create a third input. This is BLUE
-    new_input = add_input({'type': 'test_video', 'props': {'pattern': 6, 'zorder': 30}})
+    new_input = add_input({'type': 'test_video', 'pattern': 6, 'zorder': 30})
     cut_to_source(new_input['uid'], 1)
     time.sleep(3)
 
@@ -72,8 +72,8 @@ def subtest_overlay_of_new_input():
 def subtest_start_brave_with_mixers(run_brave, create_config_file):
     config = {
         'default_mixers': [
-            {'props': MIXER1, 'sources': {'input1': {}, 'input2': {}}},
-            {'props': MIXER2, 'sources': {'input1': {}, 'input2': {}}},
+            {**MIXER1, 'sources': {'input1': {}, 'input2': {}}},
+            {**MIXER2, 'sources': {'input1': {}, 'input2': {}}},
         ],
         'default_inputs': [INPUT1, INPUT2],
         'default_outputs': [OUTPUT1, OUTPUT2]
@@ -83,8 +83,8 @@ def subtest_start_brave_with_mixers(run_brave, create_config_file):
     check_brave_is_running()
     time.sleep(4)
     assert_mixers([
-        {'id': 1, 'props': MIXER1},
-        {'id': 2, 'props': MIXER2}
+        {'id': 1, **MIXER1},
+        {'id': 2, **MIXER2}
     ])
     assert_inputs([INPUT1, INPUT2])
     assert_outputs([OUTPUT1, OUTPUT2])

--- a/tests/test_multiple_outputs.py
+++ b/tests/test_multiple_outputs.py
@@ -5,12 +5,12 @@ from utils import *
 def start_with_multiple_outputs(run_brave, create_config_file, output_image_location1, output_image_location2):
     config = {
     'default_mixers': [
-        {'props': {'pattern': 4}}, # 4 is red
-        {'props': {'pattern': 5}} # 5 is green
+        {'pattern': 4}, # 4 is red
+        {'pattern': 5} # 5 is green
     ],
     'default_outputs': [
-        {'type': 'image', 'source': 'mixer2', 'props': { 'location': output_image_location1 }},
-        {'type': 'image', 'props': { 'location': output_image_location2 } }
+        {'type': 'image', 'source': 'mixer2',  'location': output_image_location1 },
+        {'type': 'image',  'location': output_image_location2 } 
         # ,{'type': 'local'}
     ]
     }
@@ -25,12 +25,12 @@ def test_multiple_outputs_at_startup(run_brave, create_config_file):
     output_image_location2 = create_output_image_location()
     start_with_multiple_outputs(run_brave, create_config_file, output_image_location1, output_image_location2)
     assert_outputs([
-        {'type': 'image', 'source': 'mixer2', 'props': { 'location': output_image_location1 }},
-        {'type': 'image', 'source': 'mixer1', 'props': { 'location': output_image_location2 }}
+        {'type': 'image', 'source': 'mixer2',  'location': output_image_location1 },
+        {'type': 'image', 'source': 'mixer1',  'location': output_image_location2 }
     ])
     assert_mixers([
-        {'id': 1, 'props': {'pattern': 4}},
-        {'id': 2, 'props': {'pattern': 5}}
+        {'id': 1, 'pattern': 4},
+        {'id': 2, 'pattern': 5}
     ])
 
     # If they've linked right, one will be red and the other will be green

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -35,15 +35,15 @@ def test_outputs(run_brave):
 
     # TODO outputs need to support being updated
     # # Add a property to existing output
-    # update_output(1, {'props': {'update_frequency': 5}})
-    # assert_outputs([{'type': 'image', 'id': 1, 'props': {'update_frequency': 5}}])
+    # update_output(1, {'update_frequency': 5})
+    # assert_outputs([{'type': 'image', 'id': 1, 'update_frequency': 5}])
 
     # Add a bad property to existing output
-    update_output(2, {'props': {'not_real': 100}}, 400)
+    update_output(2, {'not_real': 100}, 400)
     assert_outputs([{'type': 'local', 'id': 1}, {'type': 'image', 'id': 2}])
 
     # Add a property to missing output
-    update_output(999, {'props': {'update_frequency': 5}}, 400)
+    update_output(999, {'update_frequency': 5}, 400)
 
     # Removing an existing output works:
     delete_output(1)

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -9,7 +9,7 @@ def test_outputs(run_brave):
 
     # Create output, ignore attempts to set an ID
     add_output({'type': 'local', 'id': 99})
-    assert_outputs([{'type': 'local', 'id': 1}])
+    assert_outputs([{'type': 'local', 'id': 1, 'uid': 'output1'}])
 
     # Different types of outputs work:
     add_output({'type': 'image'})

--- a/tests/test_outputs_with_input_source.py
+++ b/tests/test_outputs_with_input_source.py
@@ -11,7 +11,7 @@ def test_outputs_with_input_source(run_brave):
     subtest_deleting_mixer_removes_it_as_source()
 
 def subtest_can_connect_input_to_output():
-    add_input({'type': 'test_video', 'props': {'pattern': 4}}) # pattern 4 is green
+    add_input({'type': 'test_video', 'pattern': 4}) # pattern 4 is green
     add_output({'type': 'image', 'source': 'input1'})
     time.sleep(1)
     assert_outputs([{'type': 'image', 'id': 1, 'source': 'input1'}])
@@ -20,7 +20,7 @@ def subtest_can_connect_input_to_output():
     assert_image_output_color(1, [255, 0, 0])
 
 def subtest_can_connect_change_output_to_another_input():
-    add_input({'type': 'test_video', 'props': {'pattern': 5}}) # pattern 5 is green
+    add_input({'type': 'test_video', 'pattern': 5}) # pattern 5 is green
 
     # Will fail whilst in PLAYING state:
     update_output(1, {'source': 'input2'}, 400)
@@ -37,7 +37,7 @@ def subtest_can_connect_change_output_to_another_input():
     assert_image_output_color(1, [0, 255, 0])
 
 def subtest_can_connect_change_output_from_input_to_mixer():
-    add_mixer({'props': {'pattern': 6}}) # pattern 5 is blue
+    add_mixer({'pattern': 6}) # pattern 5 is blue
     # Will fail whilst in PLAYING state:
     update_output(1, {'source': 'mixer1'}, 400)
     assert_outputs([{'type': 'image', 'id': 1, 'source': 'input2'}])

--- a/tests/test_overlays.py
+++ b/tests/test_overlays.py
@@ -6,30 +6,30 @@ def test_overlay_at_start(run_brave, create_config_file):
     set_up_overlay_at_start(run_brave, create_config_file)
     assert_overlays([{'id': 1}])
 
-    add_overlay({'type': 'text', 'source': 'mixer1', 'props': {'text': 'Overlay #1', 'visible': True}})
+    add_overlay({'type': 'text', 'source': 'mixer1', 'text': 'Overlay #1', 'visible': True})
     time.sleep(1)
-    assert_overlays([{'id': 1, 'source': 'mixer1', 'props': {'visible': True}},
-                     {'id': 2, 'source': 'mixer1', 'props': {'visible': True}}])
+    assert_overlays([{'id': 1, 'source': 'mixer1', 'visible': True},
+                     {'id': 2, 'source': 'mixer1', 'visible': True}])
 
     # Try adding one that's not visible:
-    add_overlay({'type': 'text', 'source': 'mixer1', 'props': {'text': 'Overlay #2', 'visible': False}})
+    add_overlay({'type': 'text', 'source': 'mixer1', 'text': 'Overlay #2', 'visible': False})
     time.sleep(1)
-    assert_overlays([{'id': 1, 'props': {'visible': True}},
-                     {'id': 2, 'props': {'visible': True}},
-                     {'id': 3, 'props': {'visible': False}}])
+    assert_overlays([{'id': 1, 'visible': True},
+                     {'id': 2, 'visible': True},
+                     {'id': 3, 'visible': False}])
 
     # Try changing visible flag
-    update_overlay(1, {'props': {'visible': False}})
-    update_overlay(3, {'props': {'visible': True}})
+    update_overlay(1, {'visible': False})
+    update_overlay(3, {'visible': True})
     time.sleep(1)
-    assert_overlays([{'id': 1, 'props': {'visible': False}},
-                     {'id': 2, 'props': {'visible': True}},
-                     {'id': 3, 'props': {'visible': True}}])
+    assert_overlays([{'id': 1, 'visible': False},
+                     {'id': 2, 'visible': True},
+                     {'id': 3, 'visible': True}])
 
     delete_overlay(3)
     time.sleep(1)
-    assert_overlays([{'id': 1, 'props': {'visible': False}},
-                     {'id': 2, 'props': {'visible': True}}])
+    assert_overlays([{'id': 1, 'visible': False},
+                     {'id': 2, 'visible': True}])
 
 
 def set_up_overlay_at_start(run_brave, create_config_file):
@@ -40,7 +40,7 @@ def set_up_overlay_at_start(run_brave, create_config_file):
         {}
     ],
     'default_overlays': [
-        {'type': 'text', 'source': 'mixer1', 'props': {'text': 'Overlay #1', 'visible': True}}
+        {'type': 'text', 'source': 'mixer1', 'text': 'Overlay #1', 'visible': True}
     ],
     'default_outputs': [
         # {'type': 'local'} # good for debugging

--- a/tests/test_overlays.py
+++ b/tests/test_overlays.py
@@ -4,7 +4,7 @@ from PIL import Image
 
 def test_overlay_at_start(run_brave, create_config_file):
     set_up_overlay_at_start(run_brave, create_config_file)
-    assert_overlays([{'id': 1}])
+    assert_overlays([{'id': 1, 'uid': 'overlay1'}])
 
     add_overlay({'type': 'text', 'source': 'mixer1', 'text': 'Overlay #1', 'visible': True})
     time.sleep(1)

--- a/tests/test_overlays_on_multiple_mixers.py
+++ b/tests/test_overlays_on_multiple_mixers.py
@@ -10,8 +10,8 @@ def test_overlays_on_multiple_mixers(run_brave, create_config_file):
                      {'id': 2, 'source': 'mixer2'},
                      {'id': 3, 'source': 'mixer1'}])
 
-    add_overlay({'type': 'text', 'source': 'mixer1', 'props': {'text': 'Overlay #3', 'visible': True}})
-    add_overlay({'type': 'text', 'source': 'mixer2', 'props': {'text': 'Overlay #4', 'visible': True}})
+    add_overlay({'type': 'text', 'source': 'mixer1', 'text': 'Overlay #3', 'visible': True})
+    add_overlay({'type': 'text', 'source': 'mixer2', 'text': 'Overlay #4', 'visible': True})
     time.sleep(1)
     assert_overlays([{'id': 1, 'source': 'mixer2'},
                      {'id': 2, 'source': 'mixer2'},
@@ -29,12 +29,12 @@ def test_overlays_on_multiple_mixers(run_brave, create_config_file):
 
 def test_overlay_on_unknown_mixer_via_api_returns_error(run_brave, create_config_file):
     init_three_overlays(run_brave, create_config_file)
-    add_overlay({'type': 'text', 'source': 'mixer999', 'props': {'text': 'Overlay #4'}}, status_code=400)
+    add_overlay({'type': 'text', 'source': 'mixer999', 'text': 'Overlay #4'}, status_code=400)
 
 
 def test_overlay_on_unknown_mixer_in_config_returns_error(run_brave, create_config_file):
     config = {'default_overlays': [
-        {'type': 'text', 'source': 'mixer999', 'props': {'text': 'No such mixer', 'visible': False}},
+        {'type': 'text', 'source': 'mixer999', 'text': 'No such mixer', 'visible': False},
     ]}
     config_file = create_config_file(config)
     run_brave(config_file.name)
@@ -46,9 +46,9 @@ def test_can_move_overlay_between_mixers(run_brave, create_config_file):
     update_overlay(1, {'source': 'mixer1'})  # Changing an invisible overlay
     update_overlay(3, {'source': 'mixer2'})  # Changing a visible overlay
     update_overlay(2, {'source': None})  # Removing a source
-    assert_overlays([{'id': 1, 'source': 'mixer1', 'props': {'visible': False}},
-                     {'id': 2, 'source': None, 'props': {'visible': True}},
-                     {'id': 3, 'source': 'mixer2', 'props': {'visible': True}}])
+    assert_overlays([{'id': 1, 'source': 'mixer1', 'visible': False},
+                     {'id': 2, 'source': None, 'visible': False},
+                     {'id': 3, 'source': 'mixer2', 'visible': True}])
 
 
 def test_handles_bad_source(run_brave, create_config_file):
@@ -68,22 +68,22 @@ def test_overlay_can_start_without_a_source(run_brave, create_config_file):
     output_video_location = create_output_video_location()
 
     config = {
-    'default_overlays': [{'type': 'text', 'source': None, 'props': {'text': 'foo', 'visible': False}}],
+    'default_overlays': [{'type': 'text', 'source': None, 'text': 'foo', 'visible': False}],
     'default_mixers': [{}]
     }
     config_file = create_config_file(config)
     run_brave(config_file.name)
     time.sleep(1)
     check_brave_is_running()
-    assert_overlays([{'id': 1, 'source': None, 'props': {'text': 'foo'}}])
+    assert_overlays([{'id': 1, 'source': None, 'text': 'foo'}])
 
     # Now update a prop, to check not having a source doesn't cause a problem
-    update_overlay(1, {'props': {'text': 'bar'}})
-    assert_overlays([{'id': 1, 'source': None, 'props': {'text': 'bar'}}])
+    update_overlay(1, {'text': 'bar'})
+    assert_overlays([{'id': 1, 'source': None, 'text': 'bar'}])
 
     # Now add a source
     update_overlay(1, {'source': 'mixer1'})
-    assert_overlays([{'id': 1, 'source': 'mixer1', 'props': {'text': 'bar'}}])
+    assert_overlays([{'id': 1, 'source': 'mixer1', 'text': 'bar'}])
 
     assert_everything_in_playing_state()
 
@@ -93,9 +93,9 @@ def init_three_overlays(run_brave, create_config_file):
 
     config = {
     'default_overlays': [
-        {'type': 'text', 'source': 'mixer2', 'props': {'text': 'Overlay #1', 'visible': False}},
-        {'type': 'text', 'source': 'mixer2', 'props': {'text': 'Overlay #2', 'visible': True}},
-        {'type': 'text', 'source': 'mixer1', 'props': {'text': 'Overlay #3', 'visible': True}}
+        {'type': 'text', 'source': 'mixer2', 'text': 'Overlay #1', 'visible': False},
+        {'type': 'text', 'source': 'mixer2', 'text': 'Overlay #2', 'visible': True},
+        {'type': 'text', 'source': 'mixer1', 'text': 'Overlay #3', 'visible': True}
     ],
     'default_mixers': [
         {},

--- a/tests/test_seek.py
+++ b/tests/test_seek.py
@@ -32,7 +32,7 @@ def test_seek(run_brave):
 def create_input():
     uri = 'file://' + test_directory() + '/assets/5_second_video.mp4'
     run_brave()
-    add_input({'type': 'uri', 'props': {'initial_state': 'PAUSED', 'uri': uri}})
+    add_input({'type': 'uri', 'initial_state': 'PAUSED', 'uri': uri})
     time.sleep(1)
 
 

--- a/tests/test_text_overlay_element_connects_successfully.py
+++ b/tests/test_text_overlay_element_connects_successfully.py
@@ -1,0 +1,56 @@
+import time, pytest, inspect
+from utils import *
+from PIL import Image
+
+def test_text_overlay_element_connects_successfully(run_brave):
+    '''
+    Confirms that the 'text' overlay creates a 'textoverlay' element and that it connects successfully.
+    '''
+    run_brave()
+
+    elements_before_adding_overlay = get_mixer_elements(1)
+
+    add_overlay({'type': 'text', 'source': 'mixer1', 'text': 'Overlay #1', 'visible': False})
+    assert_overlays([{'id': 1, 'source': 'mixer1', 'visible': False}])
+
+    check_mixer_elements_contain_one_textoverlay(elements_before_adding_overlay, is_connected=False)
+
+    # Now make visible and it will be connected
+    update_overlay(1, {'visible': True})
+    check_mixer_elements_contain_one_textoverlay(elements_before_adding_overlay, is_connected=True)
+
+    # Now make invisible and it will not be connected
+    update_overlay(1, {'visible': False})
+    check_mixer_elements_contain_one_textoverlay(elements_before_adding_overlay, is_connected=False)
+
+    # Now make active then move to another mixer... the first mixer should go down to not having that
+    update_overlay(1, {'visible': True})
+    add_mixer({})
+    update_overlay(1, {'source': 'mixer2'})
+    elements_after_moving_overlay = get_mixer_elements(1)
+    assert len(elements_after_moving_overlay) == len(elements_before_adding_overlay)
+
+    # But mixer2 will have the extra 'textoverlay' successfully
+    check_mixer_elements_contain_one_textoverlay(elements_before_adding_overlay, is_connected=True, mixer_id=2)
+
+
+def check_pads_peer(element, expect_a_peer):
+    assert ('peer' in element['pads']['video_sink']) is expect_a_peer
+    assert ('peer' in element['pads']['src']) is expect_a_peer
+
+def get_mixer_elements(mixer_id):
+    response = api_get('/api/elements')
+    assert response.status_code == 200
+    json_response = response.json()
+    return json_response['mixers'][str(mixer_id)]['elements']
+
+def check_mixer_elements_contain_one_textoverlay(elements_before_adding_overlay, is_connected=False, mixer_id=1):
+    elements = get_mixer_elements(mixer_id)
+
+    # 'textoverlay' should be the only additional element
+    assert len(elements_before_adding_overlay) == len(elements) - 1
+    textoverlay_elements = [x for x in elements if x['type'] == 'textoverlay']
+    assert len(textoverlay_elements) == 1
+
+    # The textoverlay element will not be connected
+    check_pads_peer(textoverlay_elements[0], is_connected)

--- a/tests/test_uri_input.py
+++ b/tests/test_uri_input.py
@@ -7,7 +7,7 @@ def test_uri_input_from_command_line(run_brave, create_config_file):
     config = {
         # 'enable_audio': False, # useful for debugging TODO remove
         'default_inputs': [
-            {'type': 'uri', 'props': {'uri': uri}},
+            {'type': 'uri', 'uri': uri},
         ],
         'default_outputs': [
             {'type': 'local'} # good for debugging
@@ -25,7 +25,7 @@ def test_missing_file_input_from_command_line(run_brave, create_config_file):
     config = {
         # 'enable_audio': False, # useful for debugging TODO remove
         'default_inputs': [
-            {'type': 'uri', 'props': {'uri': uri}},
+            {'type': 'uri', 'uri': uri},
         ],
         'default_outputs': [
             {'type': 'local'} # good for debugging

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -189,9 +189,9 @@ def assert_outputs(outputs, check_playing_state=True):
         actual_output = response.json()[count]
         for (key, value) in expected_output.items():
             if key == 'props':
-                for (props_key, props_value) in expected_output['props'].items():
-                    assert props_key in actual_output['props']
-                    assert props_value == actual_output['props'][props_key], 'For output %s, for key %s, expected %s but got %s' % (expected_output['id'], props_key, props_value, actual_output['props'][props_key])
+                for (props_key, props_value) in expected_output.items():
+                    assert props_key in actual_output
+                    assert props_value == actual_output[props_key], 'For output %s, for key %s, expected %s but got %s' % (expected_output['id'], props_key, props_value, actual_output[props_key])
             else:
                 assert value == actual_output[key], 'Key "%s" expected to be "%s", but was "%s"' % (key, value, actual_output[key])
 
@@ -212,9 +212,9 @@ def assert_mixers(mixers):
         actual_mixer = response.json()[count]
         for (key, value) in expected_mixer.items():
             if key == 'props':
-                for (props_key, props_value) in expected_mixer['props'].items():
-                    assert props_key in actual_mixer['props']
-                    assert props_value == actual_mixer['props'][props_key], 'For mixer %s, for key %s, expected %s but got %s' % (expected_mixer['id'], props_key, props_value, actual_mixer['props'][props_key])
+                for (props_key, props_value) in expected_mixer.items():
+                    assert props_key in actual_mixer
+                    assert props_value == actual_mixer[props_key], 'For mixer %s, for key %s, expected %s but got %s' % (expected_mixer['id'], props_key, props_value, actual_mixer[props_key])
             else:
                 assert value == actual_mixer[key], 'Key "%s" expected to be "%s", but was "%s"' % (key, value, actual_mixer[key])
 
@@ -237,12 +237,7 @@ def assert_overlays(overlays):
         actual_overlay = response.json()[count]
         for (key, value) in expected_overlay.items():
             assert key in actual_overlay
-            if key == 'props':
-                for (props_key, props_value) in expected_overlay['props'].items():
-                    assert props_key in actual_overlay['props']
-                    assert props_value == actual_overlay['props'][props_key], 'For overlay %s, for key %s, expected %s but got %s' % (expected_overlay['id'], props_key, props_value, actual_overlay['props'][props_key])
-            else:
-                assert value == actual_overlay[key], 'Key "%s" expected to be "%s", but was "%s"' % (key, value, actual_overlay[key])
+            assert value == actual_overlay[key], 'Key "%s" expected to be "%s", but was "%s"' % (key, value, actual_overlay[key])
 
 
 def add_input(details, status_code=200):
@@ -294,9 +289,9 @@ def assert_inputs(inputs, check_playing_state=True):
         for (key, value) in expected_input.items():
             assert key in actual_input
             if key == 'props':
-                for (key, value) in expected_input['props'].items():
-                    assert key in actual_input['props']
-                    assert value == actual_input['props'][key]
+                for (key, value) in expected_input.items():
+                    assert key in actual_input
+                    assert value == actual_input[key]
             else:
                 assert value == actual_input[key], 'For key "%s", expected "%s" but got "%s"' % (key, value, actual_input[key])
 


### PR DESCRIPTION
Whilst creating the API docs (‘improved_docs’ branch) I realised how rubbish the ‘props’ section was, so I’ve removed it. e.g. now instead of having to do

```
curl -X PUT -d ‘{“props:{"type": "test_video”}}' http://localhost:5000/api/inputs
```

you can do

```
curl -X PUT -d '{"type": "test_video"}' http://localhost:5000/api/inputs
```

The diff is big but it’s largely a search-and-replace job.