### PR TITLE
Ability to export config

### DIFF
--- a/brave.py
+++ b/brave.py
@@ -57,15 +57,7 @@ def start_brave():
         session.end()
 
     signal.signal(signal.SIGINT, keyboard_exit)
-
-    try:
-        session.start()
-    except brave.exceptions.InvalidConfiguration as e:
-        print('Invalid configuration: %s' % e)
-        sys.exit(1)
-    except brave.exceptions.PipelineFailure as e:
-        print('Failed to create GStreamer pipeline: %s' % e)
-        sys.exit(1)
+    session.start()
 
 
 if __name__ == '__main__':
@@ -73,5 +65,12 @@ if __name__ == '__main__':
     if not check_gstreamer_plugins():
         sys.exit(1)
     args = setup_args()
-    setup_config(args)
-    start_brave()
+    try:
+        setup_config(args)
+        start_brave()
+    except brave.exceptions.InvalidConfiguration as e:
+        print('Invalid configuration: %s' % e)
+        sys.exit(1)
+    except brave.exceptions.PipelineFailure as e:
+        print('Failed to create GStreamer pipeline: %s' % e)
+        sys.exit(1)

--- a/brave/abstract_collection.py
+++ b/brave/abstract_collection.py
@@ -9,7 +9,7 @@ class AbstractCollection(collections.abc.MutableMapping):
     def __init__(self, session):
         self.session = session
         self._items = {}
-        self._max_id = 0
+        self._next_id = 1
 
     def __getitem__(self, key):
         if key in self._items:
@@ -30,8 +30,9 @@ class AbstractCollection(collections.abc.MutableMapping):
         return len(self._items)
 
     def get_new_id(self):
-        self._max_id += 1
-        return self._max_id
+        while self._next_id in self._items:
+            self._next_id += 1
+        return self._next_id
 
     def summarise(self, for_config_file=False):
         s = []

--- a/brave/abstract_collection.py
+++ b/brave/abstract_collection.py
@@ -33,7 +33,7 @@ class AbstractCollection(collections.abc.MutableMapping):
         self._max_id += 1
         return self._max_id
 
-    def summarise(self):
+    def summarise(self, for_config_file=False):
         s = []
         for id, obj in self.items():
             s.append(obj.summarise())

--- a/brave/api/__init__.py
+++ b/brave/api/__init__.py
@@ -85,6 +85,7 @@ class RestApi(object):
         app.add_route(route_handler.get_body, '/api/outputs/<id:int>/body')
 
         app.add_route(route_handler.restart, '/api/restart', methods=['POST'])
+        app.add_route(route_handler.config_yaml, '/api/config/current.yaml', methods=['GET'])
 
         @app.websocket('/socket')
         async def feed(request, ws):

--- a/brave/config.py
+++ b/brave/config.py
@@ -16,6 +16,10 @@ def init(filename=DEFAULT_CONFIG_FILENAME):
         exit(1)
 
 
+def raw():
+    return {**c}
+
+
 def api_host():
     if 'HOST' in os.environ:
         return os.environ['HOST']
@@ -44,29 +48,29 @@ def default_mixer_height():
     return c['default_mixer_height'] if 'default_mixer_height' in c else 360
 
 
-def default_inputs():
-    if 'default_inputs' in c and c['default_inputs'] is not None:
-        return c['default_inputs']
+def inputs():
+    if 'inputs' in c and c['inputs'] is not None:
+        return c['inputs']
     else:
         return []
 
 
-def default_outputs():
-    if 'default_outputs' in c and c['default_outputs'] is not None:
-        return c['default_outputs']
+def outputs():
+    if 'outputs' in c and c['outputs'] is not None:
+        return c['outputs']
     else:
         return []
 
 
-def default_overlays():
-    if 'default_overlays' in c and c['default_overlays'] is not None:
-        return c['default_overlays']
+def overlays():
+    if 'overlays' in c and c['overlays'] is not None:
+        return c['overlays']
     else:
         return []
 
 
-def default_mixers():
-    return c['default_mixers'] if ('default_mixers' in c and c['default_mixers'] is not None) else []
+def mixers():
+    return c['mixers'] if ('mixers' in c and c['mixers'] is not None) else []
 
 
 def default_audio_caps():

--- a/brave/config.py
+++ b/brave/config.py
@@ -1,5 +1,6 @@
 import yaml
 import os
+import brave.exceptions
 DEFAULT_CONFIG_FILENAME = 'config/default.yaml'
 c = {}
 
@@ -14,6 +15,8 @@ def init(filename=DEFAULT_CONFIG_FILENAME):
     except FileNotFoundError as e:
         print('Unable to open config file "%s": %s' % (filename, e))
         exit(1)
+
+    _validate()
 
 
 def raw():
@@ -89,3 +92,19 @@ def turn_server():
     if 'TURN_SERVER' in os.environ:
         return os.environ['TURN_SERVER']
     return c['turn_server'] if 'turn_server' in c else None
+
+
+def _validate():
+    for type in ['inputs', 'outputs', 'overlays', 'mixers']:
+        if type in c and c[type] is not None:
+            if not isinstance(c[type], list):
+                raise brave.exceptions.InvalidConfiguration(
+                    'Config entry "%s" must be an array (list). It is currently: %s' % (type, c[type]))
+            for entry in c[type]:
+                if not isinstance(entry, dict):
+                    raise brave.exceptions.InvalidConfiguration(
+                        'Config entry "%s" contains an entry that is not a dictionary: %s' % (type, c[type]))
+                for key, value in entry.items():
+                    if not isinstance(key, str):
+                        raise brave.exceptions.InvalidConfiguration(
+                            'Config entry "%s" contains an entry with key "%s" that is not a string' % (type, key))

--- a/brave/config_file.py
+++ b/brave/config_file.py
@@ -1,0 +1,32 @@
+import yaml
+import brave.config
+import tempfile
+
+
+def as_yaml(session):
+    '''
+    Get the current config, as a YAML string.
+    This can then be used to start another Brave with the same configuration.
+    '''
+    config = brave.config.raw()
+
+    for block_type in ['inputs', 'outputs', 'overlays', 'mixers']:
+        if block_type in config:
+            del(config[block_type])
+        collection = getattr(session, block_type)
+        if len(collection) > 0:
+            config[block_type] = []
+            for name, block in collection.items():
+                config[block_type].append(block.summarise(for_config_file=True))
+    return yaml.dump(config)
+
+
+def as_yaml_file(session):
+    '''
+    Returns the current config, as a temporary YAML file.
+    '''
+    config_as_yaml = as_yaml(session)
+    fp = tempfile.NamedTemporaryFile(delete=False)
+    fp.write(config_as_yaml.encode())
+    fp.close()
+    return fp.name

--- a/brave/inputs/__init__.py
+++ b/brave/inputs/__init__.py
@@ -10,7 +10,8 @@ import brave.exceptions
 
 class InputCollection(AbstractCollection):
     def add(self, **args):
-        args['id'] = self.get_new_id()
+        if 'id' not in args:
+            args['id'] = self.get_new_id()
 
         if 'type' not in args:
             raise brave.exceptions.InvalidConfiguration("Invalid input missing 'type'")

--- a/brave/inputs/input.py
+++ b/brave/inputs/input.py
@@ -28,33 +28,34 @@ class Input(InputOutputOverlay):
         '''
         return self.session().connections.get_all_for_source(self)
 
-    def summarise(self):
-        s = super().summarise()
+    def summarise(self, for_config_file=False):
+        s = super().summarise(for_config_file)
 
-        if hasattr(self, 'pipeline'):
-            s['position'] = int(str(self.pipeline.query_position(Gst.Format.TIME).cur))
-            s['duration'] = int(str(self.pipeline.query_duration(Gst.Format.TIME).duration))
+        if not for_config_file:
+            if hasattr(self, 'pipeline'):
+                s['position'] = int(str(self.pipeline.query_position(Gst.Format.TIME).cur))
+                s['duration'] = int(str(self.pipeline.query_duration(Gst.Format.TIME).duration))
 
-            has_connection_speed, _, _ = self.pipeline.lookup('connection-speed')
-            if has_connection_speed:
-                s['connection_speed'] = self.pipeline.get_property('connection-speed')
-            has_buffer_size, _, _ = self.pipeline.lookup('buffer-size')
-            if has_buffer_size:
-                s['buffer_size'] = self.pipeline.get_property('buffer-size')
-            has_buffer_duration, _, _ = self.pipeline.lookup('buffer-duration')
-            if has_buffer_duration:
-                buffer_duration = self.pipeline.get_property('buffer-duration')
-                if buffer_duration != -1:
-                    s['buffer_duration'] = buffer_duration
+                has_connection_speed, _, _ = self.pipeline.lookup('connection-speed')
+                if has_connection_speed:
+                    s['connection_speed'] = self.pipeline.get_property('connection-speed')
+                has_buffer_size, _, _ = self.pipeline.lookup('buffer-size')
+                if has_buffer_size:
+                    s['buffer_size'] = self.pipeline.get_property('buffer-size')
+                has_buffer_duration, _, _ = self.pipeline.lookup('buffer-duration')
+                if has_buffer_duration:
+                    buffer_duration = self.pipeline.get_property('buffer-duration')
+                    if buffer_duration != -1:
+                        s['buffer_duration'] = buffer_duration
 
-            # playbin will respond with duration=-1 when not known.
-            if (s['duration'] == -1):
-                s.pop('duration', None)
+                # playbin will respond with duration=-1 when not known.
+                if (s['duration'] == -1):
+                    s.pop('duration', None)
 
-        if hasattr(self, 'get_input_cap_props'):
-            cap_props = self.get_input_cap_props()
-            if cap_props:
-                s = {**s, **cap_props}
+            if hasattr(self, 'get_input_cap_props'):
+                cap_props = self.get_input_cap_props()
+                if cap_props:
+                    s = {**s, **cap_props}
 
         return s
 
@@ -122,7 +123,7 @@ class Input(InputOutputOverlay):
         '''
         if name is None:
             name = factory_name
-        name = who_its_for.uid() + '_' + name + '_' + str(random.randint(1, 1000000))
+        name = who_its_for.uid + '_' + name + '_' + str(random.randint(1, 1000000))
         input_bin = getattr(self, 'final_' + audio_or_video + '_tee').parent
         e = Gst.ElementFactory.make(factory_name, name)
         if not input_bin.add(e):

--- a/brave/inputs/uri.py
+++ b/brave/inputs/uri.py
@@ -168,14 +168,15 @@ class UriInput(Input):
         result = self.pipeline.query(query_buffer)
         return query_buffer.parse_buffering_percent() if result else None
 
-    def summarise(self):
+    def summarise(self, for_config_file=False):
         '''
         Adds buffering stats to the summary
         '''
-        s = super().summarise()
-        buffering_stats = self.get_buffering_stats()
-        if buffering_stats:
-            s['buffering_percent'] = buffering_stats.percent
+        s = super().summarise(for_config_file)
+        if not for_config_file:
+            buffering_stats = self.get_buffering_stats()
+            if buffering_stats:
+                s['buffering_percent'] = buffering_stats.percent
         return s
 
     def on_buffering(self, buffering_percent):

--- a/brave/mixers/__init__.py
+++ b/brave/mixers/__init__.py
@@ -4,7 +4,8 @@ from brave.mixers.mixer import Mixer
 
 class MixerCollection(AbstractCollection):
     def add(self, **args):
-        args['id'] = self.get_new_id()
+        if 'id' not in args:
+            args['id'] = self.get_new_id()
         mixer = Mixer(**args, collection=self)
         self._items[args['id']] = mixer
         return mixer

--- a/brave/outputs/__init__.py
+++ b/brave/outputs/__init__.py
@@ -11,7 +11,8 @@ import brave.exceptions
 
 class OutputCollection(AbstractCollection):
     def add(self, **args):
-        args['id'] = self.get_new_id()
+        if 'id' not in args:
+            args['id'] = self.get_new_id()
 
         if 'type' not in args:
             raise brave.exceptions.InvalidConfiguration("Invalid output, no 'type'")

--- a/brave/outputs/output.py
+++ b/brave/outputs/output.py
@@ -36,9 +36,9 @@ class Output(InputOutputOverlay):
     def input_output_overlay_or_mixer(self):
         return 'output'
 
-    def summarise(self):
-        s = super().summarise()
-        s['source'] = self.source().uid() if self.source() else None
+    def summarise(self, for_config_file=False):
+        s = super().summarise(for_config_file)
+        s['source'] = self.source().uid if self.source() else None
         return s
 
     def source(self):
@@ -149,7 +149,7 @@ class Output(InputOutputOverlay):
             return
 
         if self.source():
-            self.logger.info('Request to change source from %s to %s' % (self.source().uid(), new_src.uid()))
+            self.logger.info('Request to change source from %s to %s' % (self.source().uid, new_src.uid))
             self.source_connection().delete()
 
         self.session().connections.get_or_add_connection_between_source_and_dest(new_src, self)

--- a/brave/overlays/__init__.py
+++ b/brave/overlays/__init__.py
@@ -14,7 +14,8 @@ class OverlayCollection(AbstractCollection):
     '''
 
     def add(self, **args):
-        args['id'] = self.get_new_id()
+        if 'id' not in args:
+            args['id'] = self.get_new_id()
 
         if 'type' not in args:
             raise brave.exceptions.InvalidConfiguration("Invalid output missing 'type'")

--- a/brave/overlays/effect.py
+++ b/brave/overlays/effect.py
@@ -47,7 +47,7 @@ class EffectOverlay(Overlay):
         desc = ('videoconvert ! %s ! videoconvert ! capsfilter caps="video/x-raw,format=RGB" ! '
                 'videoconvert ! capsfilter caps="video/x-raw,format=RGBA"') % self.effect_name
         self.element = Gst.parse_bin_from_description(desc, True)
-        self.element.set_name('%s_bin' % self.uid())
+        self.element.set_name('%s_bin' % self.uid)
         place_to_add_elements = getattr(self.source, 'final_video_tee').parent
         if not place_to_add_elements.add(self.element):
             self.logger.warning('Unable to add effect overlay bin to the source pipeline')

--- a/brave/overlays/overlay.py
+++ b/brave/overlays/overlay.py
@@ -23,9 +23,9 @@ class Overlay(InputOutputOverlay):
     def has_audio(self):
         return False   # no such thing as audio on overlays
 
-    def summarise(self):
-        s = super().summarise()
-        s['source'] = self.source.uid() if self.source else None
+    def summarise(self, for_config_file=False):
+        s = super().summarise(for_config_file)
+        s['source'] = self.source.uid if self.source else None
         return s
 
     def update(self, updates):
@@ -62,7 +62,7 @@ class Overlay(InputOutputOverlay):
             self.source = None
             return
 
-        if hasattr(self, 'source') and self.source is not None and self.source.uid() == new_source_uid:
+        if hasattr(self, 'source') and self.source is not None and self.source.uid == new_source_uid:
             return
 
         # If overlay is visible, then it's attached. We must make it invisible first.

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -15,7 +15,7 @@ default_mixer_height: 360
 ## Here you can define inputs that should exist at startup.
 ## Types available: 'uri', 'image', 'test_video', 'test_audio'
 ##
-default_inputs:
+inputs:
     # - type: uri
     #   zorder: 2
     #   uri: file:///path/to/file.mp4
@@ -34,7 +34,7 @@ default_inputs:
 ## Here you can define inputs that should exist at startup.
 ## Types available: 'rtmp', 'tcp, 'image', 'file', 'local'
 ##
-default_outputs:
+outputs:
     # - type: local
     # - type: file
     #   location: /path/to/file.mp4
@@ -47,7 +47,7 @@ default_outputs:
 ## DEFAULT OVERLAYS
 ## Types available: 'text', 'clock', 'effect'
 ##
-default_overlays:
+overlays:
     # - type: text
     #   text: 'I am some text'
     #   visible: true
@@ -63,6 +63,6 @@ default_overlays:
 ## No 'type' field requided for mixers.
 ## 'props' can have 'width' and 'height' and 'pattern' (all integers)
 ##
-default_mixers:
+mixers:
     # Default to one mixer, with no specific props:
     - {}

--- a/config/example_four_squares.yaml
+++ b/config/example_four_squares.yaml
@@ -2,7 +2,7 @@ enable_audio: false
 default_mixer_width: 640
 default_mixer_height: 360
 
-default_inputs:
+inputs:
     - type: test_video
       props:
           pattern: 18
@@ -28,5 +28,5 @@ default_inputs:
           xpos: 320
           ypos: 180
 
-default_outputs:
+outputs:
     - type: local

--- a/config/example_test_sounds.yaml
+++ b/config/example_test_sounds.yaml
@@ -1,6 +1,6 @@
 enable_video: false
 
-default_inputs:
+inputs:
     - type: test_audio
       props:
           freq: 200
@@ -13,5 +13,5 @@ default_inputs:
           freq: 600
           volume: 0.2
 
-default_outputs:
+outputs:
     - type: local

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,9 +95,9 @@ curl http://localhost:5000/api/all
 ### Restart Brave
 Restart Brave. This will reset all settings and connections.
 
-- *Path:* `/api/restart`
-- *Method:* `POST`
-- *Body:* JSON, containing one key `config` set to either `original` or `current`.
+- Path: `/api/restart`
+- Method: `POST`
+- Request body: JSON, containing one key `config` set to either `original` or `current`.
 If set to `original`, restarts Brave with the orginal config file from when the current process started. If `current`, restarts Brave with the current config, so that the exact setup can be recreated.
 
 #### Command-line curl example
@@ -137,9 +137,9 @@ curl http://localhost:5000/api/inputs
 ### Create an input
 Create a new input. There are different types of inputs. You must specify a `type`, and [depending on the input type chosen](./inputs.md), there may be other required or optional parameters.
 
-- *Path:* `/api/inputs`
-- *Method:* `PUT`
-- *Body:* JSON, containing a dictionary with the required parameters.
+- Path: `/api/inputs`
+- Method: `PUT`
+- Request body: JSON, containing a dictionary with the required parameters.
 
 #### Command-line curl example
 ```
@@ -159,7 +159,7 @@ Update an existing input. The `id` (integer) of the input is required in the pat
 
 - Path: `/api/inputs/<id>`
 - Method: `POST`
-- Request body: JSON containing the changes
+- Request body: JSON, containing a dictionary with the changes.
 
 #### Command-line curl example
 ```
@@ -204,6 +204,7 @@ Create a new mixer. Optionally, provide, width, height and pattern. See [Mixers]
 
 - Path: `/api/mixers`
 - Method: `PUT`
+- Request body: JSON, containing a dictionary with the required parameters.
 
 #### Command-line curl example
 ```
@@ -231,6 +232,7 @@ Update an existing mixer. The `id` (integer) of the mixer is required in the pat
 
 - Path: `/api/mixers/<id>`
 - Method: `POST`
+- Request body: JSON, containing a dictionary with the changes.
 
 #### Command-line curl example
 ```
@@ -319,6 +321,7 @@ Create a new output. There are different types of outputs. You must specify a `t
 
 - Path: `/api/outputs`
 - Method: `PUT`
+- Request body: JSON, containing a dictionary with the required parameters.
 
 #### Command-line curl example
 ```
@@ -388,6 +391,7 @@ Create a new overlay. There are different types of overlays. You must specify a 
 
 - Path: `/api/overlays`
 - Method: `PUT`
+- Request body: JSON, containing a dictionary with the required parameters.
 
 #### Command-line curl example
 ```
@@ -408,7 +412,7 @@ Update an existing overlay. The `id` (integer) of the overlay is required in the
 
 - Path: `/api/overlays/<id>`
 - Method: `POST`
-- Request body: JSON containing the changes
+- Request body: JSON, containing a dictionary with the changes.
 
 #### Command-line curl example
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -100,7 +100,21 @@ Restart Brave. This will reset all settings and connections.
 
 #### Command-line curl example
 ```
-curl -X POST -d {}  http://localhost:5000/api/restart
+curl -X POST -d {'config':'original'}  http://localhost:5000/api/restart
+```
+
+### Get config as YAML
+Get the current config in YAML. This can then be saved as a file which is
+accepted by another Brave instance on startup.
+
+- Path: `/api/config/current.yaml`
+- Method: `GET`
+
+#### Command-line curl example
+```
+curl http://127.0.0.1:5000/api/config/current.yaml > /tmp/config.yaml
+# Which you could then pass to Brave on another occasion, e.g.
+brave.py -c /tmp/config.yaml
 ```
 
 ## Inputs
@@ -123,6 +137,8 @@ Create a new input. There are different types of inputs. You must specify a `typ
 
 - Path: `/api/inputs`
 - Method: `PUT`
+- Body: JSON, containing one key `type` set to either `original` or `current`.
+If set to `original`, restarts Brave with the orginal config file from when the current process started. If `current`, restarts Brave with the current config, so that the exact setup can be recreated.
 
 #### Command-line curl example
 ```
@@ -195,6 +211,10 @@ curl -X PUT -d '{}' http://localhost:5000/api/mixers
 
 # Create a mixer, of size 1280x720, with a black background
 curl -X PUT -d '{"pattern": 2, "width": 1280, "height": 720}' http://localhost:5000/api/mixers
+
+# Create a mixer, taking input1 as a source
+curl -X PUT -d '{"sources": [{"uid": "input1"}]}' http://localhost:5000/api/mixers
+
 ```
 
 #### Example response

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,8 +95,10 @@ curl http://localhost:5000/api/all
 ### Restart Brave
 Restart Brave. This will reset all settings and connections.
 
-- Path: `/api/restart`
-- Method: `POST`
+- *Path:* `/api/restart`
+- *Method:* `POST`
+- *Body:* JSON, containing one key `config` set to either `original` or `current`.
+If set to `original`, restarts Brave with the orginal config file from when the current process started. If `current`, restarts Brave with the current config, so that the exact setup can be recreated.
 
 #### Command-line curl example
 ```
@@ -135,10 +137,9 @@ curl http://localhost:5000/api/inputs
 ### Create an input
 Create a new input. There are different types of inputs. You must specify a `type`, and [depending on the input type chosen](./inputs.md), there may be other required or optional parameters.
 
-- Path: `/api/inputs`
-- Method: `PUT`
-- Body: JSON, containing one key `type` set to either `original` or `current`.
-If set to `original`, restarts Brave with the orginal config file from when the current process started. If `current`, restarts Brave with the current config, so that the exact setup can be recreated.
+- *Path:* `/api/inputs`
+- *Method:* `PUT`
+- *Body:* JSON, containing a dictionary with the required parameters.
 
 #### Command-line curl example
 ```

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -37,12 +37,12 @@ Config files are written in [YAML](http://yaml.org/), and are simple to create b
 The following options can be included in the config file.
 
 ### Inputs
-Use the `default_inputs` entry to provide an array of inputs that should be created when Brave starts.
+Use the `inputs` entry to provide an array of inputs that should be created when Brave starts.
 
 Example:
 
 ```
-default_inputs:
+inputs:
      - type: test_video
      - type: uri
        state: PAUSED
@@ -56,13 +56,13 @@ Each input must have a type (e.g. `uri`). Inputs also have a range of other prop
 
 
 ### Mixers
-Use the `default_mixers` entry to provide an array of inputs that should be created when Brave starts. If omitted, one mixer will automatically be created.
+Use the `mixers` entry to provide an array of inputs that should be created when Brave starts. If omitted, one mixer will automatically be created.
 
 
 Example:
 
 ```
-default_mixers:
+mixers:
     - width: 640
       height: 360
       pattern: 6
@@ -73,12 +73,12 @@ default_mixers:
 Unlike inputs, outputs and overlays, mixers do not have a type. The [mixers](mixers.md) page shows the properties that a mixer can have.
 
 ### Outputs
-Use `default_outputs` to define an array of outputs that should be created when Brave starts.
+Use `outputs` to define an array of outputs that should be created when Brave starts.
 
 Example (creating four outputs of different types):
 
 ```
-default_outputs:
+outputs:
     - type: local
       state: READY
       input_id: 0
@@ -95,12 +95,12 @@ default_outputs:
 Each output must have a type (either 'rtmp', 'tcp', 'image', 'file', 'local', or 'webrtc'). Outputs also have a range of other properties. For the full list, see the [outputs](outputs.md) page.
 
 ### Overlays
-`default_overlays` is an array of overlays that should be created when Brave starts.
+`overlays` is an array of overlays that should be created when Brave starts.
 
 Example:
 
 ```
-default_overlays:
+overlays:
     - type: text
       text: 'I am some text'
       visible: true

--- a/docs/install_kvs.md
+++ b/docs/install_kvs.md
@@ -56,7 +56,7 @@ You can instruct Brave to output the stream either by adding it to Brave's confi
 Here is an example config file to set up one stream:
 
 ```
-default_outputs:
+outputs:
     - type: kvs
       stream_name: 'name-of-your-stream'
 ```

--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,7 @@
           </button>
           <div class="dropdown-menu">
             <a class="dropdown-item" href="#" id="restart-brave-button">Restart Brave</a>
+            <a class="dropdown-item" href="api/config/current.yaml">Download current config</a>
             <a class="dropdown-item" href="#" id="refresh-page-button">Refresh page</a>
             <a class="dropdown-item" target="_blank" href="elements_table">Debug view (GStreamer elements)</a>
           </div>

--- a/public/js/inputs.js
+++ b/public/js/inputs.js
@@ -24,7 +24,7 @@ inputsHandler.showFormToEdit = function(input) {
 inputsHandler.seek = function(input) {
     var end = input.duration/GstSecond
     secondsSeek = prompt("What should input " + input.id + "seek to, in seconds. (0=start, " + end + "=end)");
-    inputsHandler._submitCreateOrEdit(input.id, {position:secondsSeek*GstSecond})
+    submitCreateOrEdit('input', input.id, {position:secondsSeek*GstSecond})
 }
 
 inputsHandler._drawCards = () => {
@@ -42,10 +42,13 @@ inputsHandler._asCard = (input) => {
 }
 
 inputsHandler._optionButtonsForInput = (input) => {
-    var editButton   = components.editButton().click(() => { inputsHandler.showFormToEdit(input); return false })
-    var deleteButton = components.deleteButton().click(() => { inputsHandler.delete(input); return false })
-    var seekButton   = components.seekButton().click(() => { inputsHandler.seek(input); return false })
-    return [editButton, deleteButton, seekButton]
+    const buttons = []
+    buttons.push(components.editButton().click(() => { inputsHandler.showFormToEdit(input); return false }))
+    buttons.push(components.deleteButton().click(() => { inputsHandler.delete(input); return false }))
+    if (input.type === 'uri') {
+        buttons.push(components.seekButton().click(() => { inputsHandler.seek(input); return false }))
+    }
+    return buttons
 }
 
 inputsHandler._inputCardBody = (input) => {
@@ -296,8 +299,8 @@ inputsHandler._handleFormSubmit = function() {
         }
     })
 
-    const loop_entry = form.find('[name="loop"]')
-    if (loop_entry) newProps.loop = loop_entry.is(":checked")
+    const loopEntry = form.find('[name="loop"]')
+    if (loopEntry && loopEntry.length > 0) newProps.loop = loopEntry.is(":checked")
 
     if (newProps.volume) newProps.volume /= 100 // convert percentage
     if (newProps.buffer_duration) newProps.buffer_duration *= GstSecond
@@ -339,7 +342,7 @@ inputsHandler._handleFormSubmit = function() {
         return
     }
 
-    inputsHandler._submitCreateOrEdit(id, newProps)
+    submitCreateOrEdit('input', id, newProps)
     hideModal();
 }
 
@@ -360,26 +363,8 @@ inputsHandler.delete = function(input) {
     return false
 }
 
-inputsHandler._submitCreateOrEdit = function (id, values) {
-    const type = (id != null) ? 'POST' : 'PUT'
-    const url = (id != null) ? 'api/inputs/' + id : 'api/inputs'
-    $.ajax({
-        contentType: 'application/json',
-        type, url,
-        dataType: 'json',
-        data: JSON.stringify(values),
-        success: function() {
-            showMessage('Successfully created or updated an input', 'success')
-            updatePage()
-        },
-        error: function() {
-            showMessage('Sorry, an error occurred', 'danger')
-        }
-    });
-}
-
 inputsHandler.setState = function(id, state) {
-    return inputsHandler._submitCreateOrEdit(id, {state})
+    return submitCreateOrEdit('input', id, {state})
 }
 
 inputsHandler.patternTypes = [

--- a/public/js/mixers.js
+++ b/public/js/mixers.js
@@ -18,7 +18,7 @@ mixersHandler.draw = function() {
 }
 
 mixersHandler.setState = function(id, state) {
-    return mixersHandler._submitCreateOrEdit(id, {state})
+    submitCreateOrEdit('mixer', id, {state})
 }
 
 mixersHandler.remove = (mixer, source) => {
@@ -119,34 +119,12 @@ mixersHandler._handleFormSubmit = function() {
         }
     })
     splitDimensionsIntoWidthAndHeight(newProps)
-    console.log('Submitting new mixer with values', newProps)
-    mixersHandler._submitCreateOrEdit(id, newProps)
+    submitCreateOrEdit('mixer', id, newProps)
     hideModal();
 }
 
 mixersHandler.create = () => {
-    mixersHandler._submitCreateOrEdit(null, {})
-}
-
-
-mixersHandler._submitCreateOrEdit = function (id, values) {
-    var putOrPost = (id != null) ? 'POST' : 'PUT'
-    var url = (id != null) ? 'api/mixers/' + id : 'api/mixers'
-    $.ajax({
-        contentType: 'application/json',
-        type: putOrPost,
-        url: url,
-        dataType: 'json',
-        data: JSON.stringify(values),
-        success: function() {
-            showMessage('Successfully created/updated mixer', 'success')
-            updatePage()
-        },
-        error: function(response) {
-            showMessage(response.responseJSON && response.responseJSON.error ?
-                'Error updating mixer: ' + response.responseJSON.error : 'Error updating mixer')
-        }
-    });
+    submitCreateOrEdit('mixer', null, {})
 }
 
 mixersHandler.delete = function(mixer) {

--- a/public/js/outputs.js
+++ b/public/js/outputs.js
@@ -91,11 +91,7 @@ outputsHandler._outputCardBody = (output) => {
 }
 
 outputsHandler.requestNewOutput = function(args) {
-    outputsHandler._submitCreateOrEdit(null, args, (response) => {
-        if (!response || !response.hasOwnProperty('id')) {
-            showMessage('Unable to create output', 'warning')
-        }
-    })
+    submitCreateOrEdit('output', null, args)
 }
 
 function getVideoElement() {
@@ -271,31 +267,10 @@ outputsHandler._handleFormSubmit = function() {
     }
 
     if (newProps.source === 'none') newProps.source = null
-    outputsHandler._submitCreateOrEdit(output.id, newProps, outputsHandler._onNewOutputSuccess)
+    submitCreateOrEdit('output', output.id, newProps)
     hideModal();
 }
 
-outputsHandler._onNewOutputSuccess = function() {
-    showMessage('Successfully created a new output', 'success')
-    updatePage()
-}
-
-outputsHandler._submitCreateOrEdit = function(id, values, onSuccess) {
-    var type = (id != null) ? 'POST' : 'PUT'
-    var url = (id != null) ? 'api/outputs/' + id : 'api/outputs'
-    $.ajax({
-        contentType: 'application/json',
-        type, url,
-        dataType: 'json',
-        data: JSON.stringify(values),
-        success: onSuccess,
-        error: function(response) {
-            showMessage(response.responseJSON && response.responseJSON.error ?
-                'Error creating output: ' + response.responseJSON.error : 'Error creating output')
-        }
-    });
-}
-
 outputsHandler.setState = function(id, state) {
-    return outputsHandler._submitCreateOrEdit(id, {state})
+    submitCreateOrEdit('output', id, {state})
 }

--- a/public/js/overlays.js
+++ b/public/js/overlays.js
@@ -49,11 +49,11 @@ overlaysHandler._overlayCardBody = (overlay) => {
 }
 
 overlaysHandler.overlay = (overlay) => {
-    overlaysHandler._submitCreateOrEdit(overlay.id, {visible: true})
+    submitCreateOrEdit('overlay', overlay.id, {visible: true})
 }
 
 overlaysHandler.remove = (overlay) => {
-    overlaysHandler._submitCreateOrEdit(overlay.id, {visible: false})
+    submitCreateOrEdit('overlay', overlay.id, {visible: false})
 }
 
 overlaysHandler._getMixOptions = (overlay) => {
@@ -211,30 +211,8 @@ overlaysHandler._handleFormSubmit = function() {
     }
 
     if (newProps.source === 'none') newProps.source = null
-    console.log('Submitting new overlay with values', newProps)
-    overlaysHandler._submitCreateOrEdit(id, newProps)
+    submitCreateOrEdit('overlay', id, newProps)
     hideModal();
-}
-
-
-overlaysHandler._submitCreateOrEdit = function (id, values) {
-    var putOrPost = (id != null) ? 'POST' : 'PUT'
-    var url = (id != null) ? 'api/overlays/' + id : 'api/overlays'
-    $.ajax({
-        contentType: 'application/json',
-        type: putOrPost,
-        url: url,
-        dataType: 'json',
-        data: JSON.stringify(values),
-        success: function() {
-            showMessage('Successfully created/updated overlay', 'success')
-            updatePage()
-        },
-        error: function(response) {
-            showMessage(response.responseJSON && response.responseJSON.error ?
-                'Error updating overlay: ' + response.responseJSON.error : 'Error updating overlay')
-        }
-    });
 }
 
 overlaysHandler.valignmentTypes = {

--- a/tests/test_add_and_remove_from_mix.py
+++ b/tests/test_add_and_remove_from_mix.py
@@ -4,57 +4,57 @@ from PIL import Image
 
 def test_adding_and_removing_sources_to_a_mix(run_brave, create_config_file):
     set_up_two_sources(run_brave, create_config_file)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': True}, {'id': 2, 'block_type': 'input', 'in_mix': True}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': True}, {'uid': 'input2', 'in_mix': True}])
     remove_source('input2', 1)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': True}, {'id': 2, 'block_type': 'input', 'in_mix': False}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': True}, {'uid': 'input2', 'in_mix': False}])
     remove_source('input2', 1)  # Prove it's safe to do repeatedly
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': True}, {'id': 2, 'block_type': 'input', 'in_mix': False}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': True}, {'uid': 'input2', 'in_mix': False}])
     remove_source('input1', 1)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': False}, {'id': 2, 'block_type': 'input', 'in_mix': False}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': False}, {'uid': 'input2', 'in_mix': False}])
     overlay_source('input2', 1)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': False}, {'id': 2, 'block_type': 'input', 'in_mix': True}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': False}, {'uid': 'input2', 'in_mix': True}])
     overlay_source('input2', 1) # Prove it's safe to do repeatedly
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': False}, {'id': 2, 'block_type': 'input', 'in_mix': True}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': False}, {'uid': 'input2', 'in_mix': True}])
     overlay_source('input1', 1)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': True}, {'id': 2, 'block_type': 'input', 'in_mix': True}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': True}, {'uid': 'input2', 'in_mix': True}])
 
 
 def test_removing_input_whilst_in_a_mix(run_brave, create_config_file):
     set_up_two_sources(run_brave, create_config_file)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': True}, {'id': 2, 'block_type': 'input', 'in_mix': True}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': True}, {'uid': 'input2', 'in_mix': True}])
     assert_number_of_sinks_on_mixer(3) # 3 because there's always a dummy one with test video src
     delete_input(2)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': True}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': True}])
     assert_number_of_sinks_on_mixer(2)
 
 
 def test_switching(run_brave, create_config_file):
     set_up_two_sources(run_brave, create_config_file)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': True}, {'id': 2, 'block_type': 'input', 'in_mix': True}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': True}, {'uid': 'input2', 'in_mix': True}])
     cut_to_source('input2', 1)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': False}, {'id': 2, 'block_type': 'input', 'in_mix': True}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': False}, {'uid': 'input2', 'in_mix': True}])
     cut_to_source('input1', 1)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': True}, {'id': 2, 'block_type': 'input', 'in_mix': False}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': True}, {'uid': 'input2', 'in_mix': False}])
     cut_to_source('input1', 1)
-    assert_api_returns_right_mixer_sources([{'id': 1, 'block_type': 'input', 'in_mix': True}, {'id': 2, 'block_type': 'input', 'in_mix': False}])
+    assert_api_returns_right_mixer_sources([{'uid': 'input1', 'in_mix': True}, {'uid': 'input2', 'in_mix': False}])
 
 def set_up_two_sources(run_brave, create_config_file):
     output_video_location = create_output_video_location()
 
     config = {
-    'default_inputs': [
+    'inputs': [
         {'type': 'test_video', 'pattern': 4, 'zorder': 2}, # pattern 4 is red
         {'type': 'test_video', 'pattern': 5, 'zorder': 3}, # pattern 5 is green
     ],
-    'default_mixers': [
+    'mixers': [
         {
-            'sources': {
-                'input1': {},
-                'input2': {},
-            }
+            'sources': [
+                {'uid': 'input1'},
+                {'uid': 'input2'},
+            ]
         }
     ],
-    'default_outputs': [
+    'outputs': [
         # {'block_type': 'local'} # good for debugging
     ]
     }
@@ -67,9 +67,6 @@ def set_up_two_sources(run_brave, create_config_file):
 def assert_api_returns_right_mixer_sources(inputs):
     response = api_get('/api/all')
     assert response.status_code == 200
-    for i in inputs:
-        i['uid'] = '%s%d' % (i['block_type'], i['id'])
-
     if len(inputs) == 0:
         assert ('sources' not in response.json()['mixers'][0]) or \
                (len(response.json()['mixers'][0]['sources']) == 0)

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -1,4 +1,5 @@
 import time, pytest, inspect
+import yaml
 from utils import *
 
 
@@ -13,7 +14,7 @@ def test_brave_with_missing_config_file(run_brave):
 
 
 def test_brave_with_invalid_input_type(run_brave, create_config_file):
-    config = {'default_inputs': [{'type': 'not-a-valid-type'}]}
+    config = {'inputs': [{'type': 'not-a-valid-type'}]}
     config_file = create_config_file(config)
     run_brave(config_file.name)
     check_return_value(1)
@@ -25,13 +26,13 @@ def test_brave_with_full_config_file(run_brave, create_config_file):
     file_asset = test_directory() + '/assets/5_second_video.mp4'
 
     config = {
-    'default_inputs': [
+    'inputs': [
         {'type': 'test_video'},
         {'type': 'test_audio',  'freq': 200 } ,
         {'type': 'test_audio',  'freq': 600 } ,
         {'type': 'uri',  'uri': 'file://' + file_asset }
     ],
-    'default_outputs': [
+    'outputs': [
         {'type': 'local', 'source': 'input4'},
         {'type': 'tcp'},
         {'type': 'file', 'source': 'input1',  'location': output_video_location},

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -58,3 +58,52 @@ def test_brave_with_full_config_file(run_brave, create_config_file):
     assert response.json()['outputs'][2]['location'] == output_video_location
     assert response.json()['outputs'][2]['source'] == 'input1'
     assert response.json()['outputs'][3]['source'] == 'input2'
+
+
+def test_non_string_keys(run_brave, create_config_file):
+    config = {
+        'inputs': [
+            { 1: 'oh look 1 is not a string'}
+        ]
+    }
+    config_file = create_config_file(config)
+    run_brave(config_file.name)
+    check_return_value(1)
+
+
+def test_config_file_with_ids(run_brave, create_config_file):
+    config = {
+    'inputs': [
+        {'type': 'test_video'},
+        {'type': 'test_video', 'id': 10}
+    ],
+    'outputs': [
+        {'type': 'image', 'id': 1},
+        {'type': 'image'},
+        {'type': 'image'}
+    ],
+    'mixers': [
+        {},
+        {'id': 2}
+    ],
+    'overlays': [
+        {'type': 'clock', 'id': 7}
+    ],
+    }
+    config_file = create_config_file(config)
+    run_brave(config_file.name)
+    check_brave_is_running()
+    response = api_get('/api/all')
+    assert response.status_code == 200
+    assert len(response.json()['inputs']) == 2
+    assert len(response.json()['outputs']) == 3
+    assert len(response.json()['mixers']) == 2
+    assert len(response.json()['overlays']) == 1
+    assert response.json()['inputs'][0]['id'] == 1
+    assert response.json()['inputs'][1]['id'] == 10
+    assert response.json()['outputs'][0]['id'] == 1
+    assert response.json()['outputs'][1]['id'] == 2
+    assert response.json()['outputs'][2]['id'] == 3
+    assert response.json()['mixers'][0]['id'] == 1
+    assert response.json()['mixers'][1]['id'] == 2
+    assert response.json()['overlays'][0]['id'] == 7

--- a/tests/test_config_file_output.py
+++ b/tests/test_config_file_output.py
@@ -1,0 +1,74 @@
+import time, pytest, inspect
+import yaml
+from utils import *
+
+'''
+Tests for /api/config/current.yaml
+'''
+
+def test_empty_config_file(run_brave, create_config_file):
+    config = {}
+    subtest_start_brave_and_check_config_file(run_brave, create_config_file, config)
+
+def test_simple_config_file(run_brave, create_config_file):
+    config = {
+        'enable_video': False,
+        'inputs': [{'type': 'test_video'}],
+        'mixers': [{}],
+        'outputs': [{'type': 'local', 'source': 'input1'}],
+    }
+    subtest_start_brave_and_check_config_file(run_brave, create_config_file, config)
+
+def test_complex_config_file(run_brave, create_config_file):
+    config = {
+        'default_mixer_width': 123,
+        'stun_server': 'some_stun_server',
+        'inputs': [
+            {'type': 'test_video'},
+            {'type': 'test_audio',  'freq': 200 } ,
+            {'type': 'test_audio',  'freq': 600, 'id': 6 }
+        ],
+        'mixers': [
+            {'sources': [{'uid': 'input1'}, {'uid': 'input2'}]},
+            {'state': 'READY', 'id': 2} ,
+        ],
+        'overlays': [
+            {'type': 'clock', 'valignment': 'top', 'source': 'input1', 'id': 9}
+        ],
+        'outputs': [
+            {'type': 'local', 'source': 'input6', 'id': 17},
+            {'type': 'tcp', 'source': 'input2'},
+            {'type': 'file', 'source': 'input1', 'location': '/tmp/x', 'state': 'NULL'},
+            {'type': 'image', 'source': 'mixer2'}
+        ]
+    }
+
+    subtest_start_brave_and_check_config_file(run_brave, create_config_file, config)
+
+def subtest_start_brave_and_check_config_file(run_brave, create_config_file, config):
+    config_file = create_config_file(config)
+    run_brave(config_file.name)
+    time.sleep(0.5)
+    check_brave_is_running()
+    subtest_validate_config_response(config)
+
+def subtest_validate_config_response(orig):
+    config_response = api_get('/api/config/current.yaml')
+    assert config_response.status_code == 200
+    parsed = yaml.load(config_response.text)
+
+    check_first_dict_exists_in_second(orig, parsed)
+
+def check_first_dict_exists_in_second(a, b):
+    for key, value in a.items():
+        assert key in b
+        if isinstance(value, list):
+            check_first_array_exists_in_second(value, b[key])
+        else:
+            # print('Comparing %s with %s' % (value, b[key]))
+            assert value == b[key]
+
+def check_first_array_exists_in_second(a, b):
+    assert len(a) == len(b)
+    for i in range(len(a)):
+        check_first_dict_exists_in_second(a[i], b[i])

--- a/tests/test_effect_overlay.py
+++ b/tests/test_effect_overlay.py
@@ -52,8 +52,8 @@ def test_set_up_effect_overlay_in_config_file(run_brave, create_config_file):
     output_video_location = create_output_video_location()
 
     config = {
-    'default_mixers': [{}],
-    'default_overlays': [
+    'mixers': [{}],
+    'overlays': [
         {'type': 'effect', 'source': 'mixer1', 'effect_name': 'burn', 'visible': True},
         {'type': 'effect', 'source': 'mixer1', 'effect_name': 'vertigotv', 'visible': False}
     ]

--- a/tests/test_file_output.py
+++ b/tests/test_file_output.py
@@ -6,10 +6,10 @@ def test_can_create_video_file_output(run_brave, create_config_file):
     output_video_location = create_output_video_location()
 
     config = {
-    'default_inputs': [
+    'inputs': [
         {'type': 'test_video', 'pattern': 4, 'zorder': 2}, # pattern 4 is red
     ],
-    'default_outputs': [
+    'outputs': [
         {'type': 'file',  'location': output_video_location } 
         # ,{'type': 'local'} # good for debugging
     ]

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -6,11 +6,11 @@ def test_image_input_from_command_line(run_brave, create_config_file):
     image_uri = 'file://' + test_directory() + '/assets/image_640_360.png'
     config = {
         'enable_audio': False, # useful for debugging TODO remove
-        'default_inputs': [
+        'inputs': [
             # {'type': 'test_video', 'pattern': 4, 'zorder': 2}, # pattern 4 is red
             {'type': 'image', 'uri': image_uri}, # pattern 4 is red
         ],
-        'default_outputs': [
+        'outputs': [
             {'type': 'local'} # good for debugging
         ]
     }

--- a/tests/test_image_output.py
+++ b/tests/test_image_output.py
@@ -6,11 +6,11 @@ def test_image_output(run_brave, create_config_file):
     output_image_location = create_output_image_location()
 
     config = {
-    'default_mixers': [{'sources': {'input1': {}}}],
-    'default_inputs': [
+    'mixers': [{'sources': [{'uid': 'input1'}]}],
+    'inputs': [
         {'type': 'test_video', 'pattern': 4, 'zorder': 2}, # pattern 4 is red
     ],
-    'default_outputs': [
+    'outputs': [
         {'type': 'local'}, # good for debugging
         {'type': 'image',  'location': output_image_location } 
     ]

--- a/tests/test_initial_state.py
+++ b/tests/test_initial_state.py
@@ -11,19 +11,19 @@ def test_state_property_on_startup(run_brave, create_config_file):
     output_image_location1 = create_output_image_location()
 
     config = {
-    'default_inputs': [
+    'inputs': [
         {'type': 'test_video', 'pattern': 4, 'state': 'PLAYING'},
         {'type': 'test_video', 'pattern': 5, 'state': 'PAUSED'},
         {'type': 'test_video', 'pattern': 6, 'state': 'READY'},
         {'type': 'test_video', 'pattern': 7, 'state': 'NULL'},
     ],
-    'default_mixers': [
+    'mixers': [
         {'state': 'PLAYING'},
         {'state': 'PAUSED'},
         {'state': 'READY'},
         {'state': 'NULL'},
     ],
-    'default_outputs': [
+    'outputs': [
         {'type': 'image', 'location': output_image_location0, 'state': 'PLAYING'},
         {'type': 'image', 'location': output_image_location0, 'state': 'PAUSED'},
         {'type': 'image', 'location': output_image_location0, 'state': 'READY'},

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -7,48 +7,51 @@ def test_inputs(run_brave):
     check_brave_is_running()
     assert_inputs([])
 
-    # Create input, ignore attempts to set an ID
+    # Create input, and can set the id
     add_input({'type': 'test_video', 'id': 99})
     time.sleep(2)
-    assert_inputs([{'type': 'test_video', 'id': 1, 'uid': 'input1'}])
+    assert_inputs([{'type': 'test_video', 'id': 99, 'uid': 'input99'}])
 
     # Different types of inputs work:
     add_input({'type': 'test_audio'})
     time.sleep(1)
-    assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2}])
+    assert_inputs([{'type': 'test_video', 'id': 99}, {'type': 'test_audio', 'id': 1}])
 
     # Change state to PAUSED
-    update_input(2, {'state': 'NULL'})
-    assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2, 'state': 'NULL'}], check_playing_state=False)
+    update_input(1, {'state': 'NULL'})
+    assert_inputs([{'type': 'test_video', 'id': 99}, {'type': 'test_audio', 'id': 1, 'state': 'NULL'}], check_playing_state=False)
 
     # Change state to READY
-    update_input(2, {'state': 'READY'})
-    assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2, 'state': 'READY'}], check_playing_state=False)
+    update_input(1, {'state': 'READY'})
+    assert_inputs([{'type': 'test_video', 'id': 99}, {'type': 'test_audio', 'id': 1, 'state': 'READY'}], check_playing_state=False)
 
     # Change state to NULL
-    update_input(2, {'state': 'PAUSED'})
-    assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2, 'state': 'PAUSED'}], check_playing_state=False)
+    update_input(1, {'state': 'PAUSED'})
+    assert_inputs([{'type': 'test_video', 'id': 99}, {'type': 'test_audio', 'id': 1, 'state': 'PAUSED'}], check_playing_state=False)
 
     # Change state to PLAYING
-    update_input(2, {'state': 'PLAYING'})
+    update_input(1, {'state': 'PLAYING'})
     time.sleep(1)
-    assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2}])
+    assert_inputs([{'type': 'test_video', 'id': 99}, {'type': 'test_audio', 'id': 1}])
 
     # Add a property to existing input
-    update_input(1, {'pattern': 5})
-    assert_inputs([{'type': 'test_video', 'id': 1, 'pattern': 5}, {'type': 'test_audio', 'id': 2}])
+    update_input(99, {'pattern': 5})
+    assert_inputs([{'type': 'test_video', 'id': 99, 'pattern': 5}, {'type': 'test_audio', 'id': 1}])
 
     # Add a bad property to existing input
-    update_input(2, {'not_real': 100}, 400)
-    assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2}])
+    update_input(1, {'not_real': 100}, 400)
+    assert_inputs([{'type': 'test_video', 'id': 99}, {'type': 'test_audio', 'id': 1}])
 
     # Add a property to missing input
     update_input(55, {'pattern': 6}, 400)
 
+    # Change an ID of an input does not work
+    update_input(99, {'id': 10}, 400)
+
     # Removing an existing input works:
-    delete_input(1)
-    assert_inputs([{'type': 'test_audio', 'id': 2}])
+    delete_input(99)
+    assert_inputs([{'type': 'test_audio', 'id': 1}])
 
     # Removing a non-existant input causes a user error
     delete_input(55, expected_status_code=400) # Does not exist
-    assert_inputs([{'type': 'test_audio', 'id': 2}])
+    assert_inputs([{'type': 'test_audio', 'id': 1}])

--- a/tests/test_mixer_to_mixer.py
+++ b/tests/test_mixer_to_mixer.py
@@ -28,7 +28,7 @@ def subtest_ensure_mixer2_is_red():
 
 def subtest_start_brave_with_two_mixers(run_brave, create_config_file):
     # Pattern 4 is red and pattern 5 is green
-    config = {'default_mixers': [{'pattern': 4}, {'pattern': 5}]}
+    config = {'mixers': [{'pattern': 4}, {'pattern': 5}]}
     config_file = create_config_file(config)
     run_brave(config_file.name)
     time.sleep(0.5)

--- a/tests/test_mixers.py
+++ b/tests/test_mixers.py
@@ -23,7 +23,7 @@ def subtest_start_brave_with_mixers(run_brave, create_config_file):
         'width': 640,
         'height': 360
     }
-    config = {'default_mixers': [MIXER1, MIXER2]}
+    config = {'mixers': [MIXER1, MIXER2]}
     config_file = create_config_file(config)
     run_brave(config_file.name)
     time.sleep(1)

--- a/tests/test_multiple_inputs_and_mixers.py
+++ b/tests/test_multiple_inputs_and_mixers.py
@@ -71,12 +71,12 @@ def subtest_overlay_of_new_input():
 
 def subtest_start_brave_with_mixers(run_brave, create_config_file):
     config = {
-        'default_mixers': [
-            {**MIXER1, 'sources': {'input1': {}, 'input2': {}}},
-            {**MIXER2, 'sources': {'input1': {}, 'input2': {}}},
+        'mixers': [
+            {**MIXER1, 'sources': [{'uid': 'input1'}, {'uid': 'input2'}]},
+            {**MIXER2, 'sources': [{'uid': 'input1'}, {'uid': 'input2'}]}
         ],
-        'default_inputs': [INPUT1, INPUT2],
-        'default_outputs': [OUTPUT1, OUTPUT2]
+        'inputs': [INPUT1, INPUT2],
+        'outputs': [OUTPUT1, OUTPUT2]
     }
     config_file = create_config_file(config)
     run_brave(config_file.name)

--- a/tests/test_multiple_outputs.py
+++ b/tests/test_multiple_outputs.py
@@ -4,11 +4,11 @@ from utils import *
 
 def start_with_multiple_outputs(run_brave, create_config_file, output_image_location1, output_image_location2):
     config = {
-    'default_mixers': [
+    'mixers': [
         {'pattern': 4}, # 4 is red
         {'pattern': 5} # 5 is green
     ],
-    'default_outputs': [
+    'outputs': [
         {'type': 'image', 'source': 'mixer2',  'location': output_image_location1 },
         {'type': 'image',  'location': output_image_location2 } 
         # ,{'type': 'local'}
@@ -40,7 +40,7 @@ def test_multiple_outputs_at_startup(run_brave, create_config_file):
 
 def test_output_at_startup_to_missing_mixer(run_brave, create_config_file):
     config = {
-    'default_outputs': [
+    'outputs': [
         {'type': 'image', 'source': 'mixer2'},
     ]
     }

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -7,31 +7,31 @@ def test_outputs(run_brave):
     check_brave_is_running()
     assert_outputs([])
 
-    # Create output, ignore attempts to set an ID
+    # Create output, including allowing the ID to be set
     add_output({'type': 'local', 'id': 99})
-    assert_outputs([{'type': 'local', 'id': 1, 'uid': 'output1'}])
+    assert_outputs([{'type': 'local', 'id': 99, 'uid': 'output99'}])
 
     # Different types of outputs work:
     add_output({'type': 'image'})
     time.sleep(1.5)
-    assert_outputs([{'type': 'local', 'id': 1}, {'type': 'image', 'id': 2}])
+    assert_outputs([{'type': 'local', 'id': 99}, {'type': 'image', 'id': 1}])
 
     # Change state to PAUSED
-    update_output(2, {'state': 'NULL'})
-    assert_outputs([{'type': 'local', 'id': 1}, {'type': 'image', 'id': 2, 'state': 'NULL'}], check_playing_state=False)
+    update_output(1, {'state': 'NULL'})
+    assert_outputs([{'type': 'local', 'id': 99}, {'type': 'image', 'id': 1, 'state': 'NULL'}], check_playing_state=False)
 
     # Change state to READY
-    update_output(2, {'state': 'READY'})
-    assert_outputs([{'type': 'local', 'id': 1}, {'type': 'image', 'id': 2, 'state': 'READY'}], check_playing_state=False)
+    update_output(1, {'state': 'READY'})
+    assert_outputs([{'type': 'local', 'id': 99}, {'type': 'image', 'id': 1, 'state': 'READY'}], check_playing_state=False)
 
     # Change state to NULL
-    update_output(2, {'state': 'PAUSED'})
-    assert_outputs([{'type': 'local', 'id': 1}, {'type': 'image', 'id': 2, 'state': 'PAUSED'}], check_playing_state=False)
+    update_output(1, {'state': 'PAUSED'})
+    assert_outputs([{'type': 'local', 'id': 99}, {'type': 'image', 'id': 1, 'state': 'PAUSED'}], check_playing_state=False)
 
     # Change state to PLAYING
-    update_output(2, {'state': 'PLAYING'})
+    update_output(1, {'state': 'PLAYING'})
     time.sleep(1)
-    assert_outputs([{'type': 'local', 'id': 1}, {'type': 'image', 'id': 2}])
+    assert_outputs([{'type': 'local', 'id': 99}, {'type': 'image', 'id': 1}])
 
     # TODO outputs need to support being updated
     # # Add a property to existing output
@@ -39,16 +39,16 @@ def test_outputs(run_brave):
     # assert_outputs([{'type': 'image', 'id': 1, 'update_frequency': 5}])
 
     # Add a bad property to existing output
-    update_output(2, {'not_real': 100}, 400)
-    assert_outputs([{'type': 'local', 'id': 1}, {'type': 'image', 'id': 2}])
+    update_output(1, {'not_real': 100}, 400)
+    assert_outputs([{'type': 'local', 'id': 99}, {'type': 'image', 'id': 1}])
 
     # Add a property to missing output
     update_output(999, {'update_frequency': 5}, 400)
 
     # Removing an existing output works:
-    delete_output(1)
-    assert_outputs([{'type': 'image', 'id': 2}])
+    delete_output(99)
+    assert_outputs([{'type': 'image', 'id': 1}])
 
     # Removing a non-existant output causes a user error
     delete_output(999, expected_status_code=400) # Does not exist
-    assert_outputs([{'type': 'image', 'id': 2}])
+    assert_outputs([{'type': 'image', 'id': 1}])

--- a/tests/test_outputs_with_no_source.py
+++ b/tests/test_outputs_with_no_source.py
@@ -28,8 +28,8 @@ def start_with_two_outputs(run_brave, create_config_file):
     output_video_location = create_output_video_location()
 
     config = {
-    'default_mixers': [{}],
-    'default_outputs': [
+    'mixers': [{}],
+    'outputs': [
         {'type': 'image', 'source': None},
         {'type': 'image'},  # Will default to mixer1
     ]

--- a/tests/test_overlays.py
+++ b/tests/test_overlays.py
@@ -36,13 +36,13 @@ def set_up_overlay_at_start(run_brave, create_config_file):
     output_video_location = create_output_video_location()
 
     config = {
-    'default_mixers': [
+    'mixers': [
         {}
     ],
-    'default_overlays': [
+    'overlays': [
         {'type': 'text', 'source': 'mixer1', 'text': 'Overlay #1', 'visible': True}
     ],
-    'default_outputs': [
+    'outputs': [
         # {'type': 'local'} # good for debugging
         {'type': 'local'}
     ]

--- a/tests/test_overlays_on_multiple_mixers.py
+++ b/tests/test_overlays_on_multiple_mixers.py
@@ -33,7 +33,7 @@ def test_overlay_on_unknown_mixer_via_api_returns_error(run_brave, create_config
 
 
 def test_overlay_on_unknown_mixer_in_config_returns_error(run_brave, create_config_file):
-    config = {'default_overlays': [
+    config = {'overlays': [
         {'type': 'text', 'source': 'mixer999', 'text': 'No such mixer', 'visible': False},
     ]}
     config_file = create_config_file(config)
@@ -68,8 +68,8 @@ def test_overlay_can_start_without_a_source(run_brave, create_config_file):
     output_video_location = create_output_video_location()
 
     config = {
-    'default_overlays': [{'type': 'text', 'source': None, 'text': 'foo', 'visible': False}],
-    'default_mixers': [{}]
+    'overlays': [{'type': 'text', 'source': None, 'text': 'foo', 'visible': False}],
+    'mixers': [{}]
     }
     config_file = create_config_file(config)
     run_brave(config_file.name)
@@ -92,12 +92,12 @@ def init_three_overlays(run_brave, create_config_file):
     output_video_location = create_output_video_location()
 
     config = {
-    'default_overlays': [
+    'overlays': [
         {'type': 'text', 'source': 'mixer2', 'text': 'Overlay #1', 'visible': False},
         {'type': 'text', 'source': 'mixer2', 'text': 'Overlay #2', 'visible': True},
         {'type': 'text', 'source': 'mixer1', 'text': 'Overlay #3', 'visible': True}
     ],
-    'default_mixers': [
+    'mixers': [
         {},
         {}
     ]

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -1,0 +1,40 @@
+import time, pytest, inspect
+from utils import *
+
+PORT_FROM_CONFIG_FILE = 12345
+PORT_FROM_COMMAND_LINE = 12346
+
+def test_restart_with_original_config(run_brave, create_config_file):
+    '''
+    WHEN user calls /api/restart with {'config':'original'}
+    THEN Brave restarts and retains original config but not any additions
+    '''
+    config = {'inputs': [{'type': 'test_video'}]}
+    config_file = create_config_file(config)
+    run_brave(config_file.name)
+    check_brave_is_running()
+    add_input({'type': 'test_audio'})
+    time.sleep(0.2)
+    assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2}])
+
+    restart_brave({'config': 'original'})
+    time.sleep(0.5)
+    assert_inputs([{'type': 'test_video', 'id': 1}])
+
+
+def test_restart_with_current_config(run_brave, create_config_file):
+    '''
+    WHEN user calls /api/restart with {'config':'current'}
+    THEN Brave restarts and retains both original config and any additions
+    '''
+    config = {'inputs': [{'type': 'test_video'}]}
+    config_file = create_config_file(config)
+    run_brave(config_file.name)
+    check_brave_is_running()
+    add_input({'type': 'test_audio'})
+    time.sleep(0.2)
+    assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2}])
+
+    restart_brave({'config': 'current'})
+    time.sleep(0.5)
+    assert_inputs([{'type': 'test_video', 'id': 1}, {'type': 'test_audio', 'id': 2}])

--- a/tests/test_uri_input.py
+++ b/tests/test_uri_input.py
@@ -6,7 +6,7 @@ FIVE_SECOND_VIDEO = 'file://' + test_directory() + '/assets/5_second_video.mp4'
 
 def test_uri_input_from_command_line(run_brave, create_config_file):
     config = {
-        'default_inputs': [
+        'inputs': [
             {'type': 'uri', 'uri': FIVE_SECOND_VIDEO},
         ]
    }
@@ -23,7 +23,7 @@ def test_uri_input_from_command_line(run_brave, create_config_file):
 
 def test_loop(run_brave, create_config_file):
     config = {
-        'default_inputs': [
+        'inputs': [
             {'type': 'uri', 'uri': FIVE_SECOND_VIDEO},
             {'type': 'uri', 'uri': FIVE_SECOND_VIDEO, 'loop': True},
         ]
@@ -55,7 +55,7 @@ def test_loop(run_brave, create_config_file):
 def test_missing_file_input_from_command_line(run_brave, create_config_file):
     uri = 'file:///does-not-exist'
     config = {
-        'default_inputs': [
+        'inputs': [
             {'type': 'uri', 'uri': uri},
         ]
     }


### PR DESCRIPTION
- Allows the current config to be exported, as a YAML that can be read by Brave, at `/api/config/current.yaml`
- Also changed `default_inputs` to `inputs` in the config file (and equivalent for `outputs`, `mixers`, and `overlays`). This makes things more consistent.
- Also changed ‘sources’ mixer property to be an array, which matches what is returned by the API
- It’s also possible to assign the ID of an input/output/mixer/overlay (so that the exact setup saved and loaded via config file).
- All this made it easy for the ‘Restart’ feature to offer the option of keeping the current config. The web interface now offers:

![image](https://user-images.githubusercontent.com/3178238/51892541-238eaf00-239a-11e9-8f02-310267946587.png)

- A few web bug fixes too (loop button does not break non-uri inputs; seek link only appears for uri inputs; more aligned code for submitting creations and updaets)


- [x] Test written
- [x] Code linted
- [x] Docs updated
