### PR TITLE
URI, TCP and RTMP input improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 _This project is an open-source prototype. See 'Project status' and 'License' below for more._
 
 Brave is a *B*asic *r*eal-time (remote) *audio/video* *e*ditor.
-It allows *LIVE* video (or audio) to be received, manipulated, and sent elsewhere.
+It allows *LIVE* video (and/or audio) to be received, manipulated, and sent elsewhere.
 It is API driven and is designed to work remotely, such as on the cloud.
 
 Example usage includes:
@@ -43,9 +43,10 @@ Brave allows you to configure *inputs*, *outputs*, *mixers* and *overlays*. You 
 ### Inputs
 An input is a source of audio or video. There can be any number of inputs, added or removed at any time, which can then be sent to mixers and outputs. Input types include:
 
-* An RTMP, RTSP, and HLS streams
+* Live and non-live streams, through protocols such as RTMP, RTSP, and HLS
 * Files (e.g. mp4 or mp3) - either local or downloaded remotely
 * Images (PNG/SVG/JPEG)
+* MPEG or OGG retrieved via a TCP connection
 * Test audio / video streams
 
 [Read more about input types.](docs/inputs.md)
@@ -187,7 +188,7 @@ GST_DEBUG=4 LOG_LEVEL=debug ./brave.py
 Brave creates multiple GStreamer pipelines, each containing multiple linked elements.
 Spotting which element has caused an error can help track down the problem.
 
-To see, select 'Debug view' from the web interface. Or, visit the `/elements` API endpoint.
+To see, select 'Debug view' from the web interface. Or, visit the `/api/elements` API endpoint.
 
 Look out for:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Example usage includes:
 
 Brave is based on GStreamer. It is, in one sense, a RESTful API for GStreamer (for live audio/video handling).
 
-Read on to learn more, or see the [FAQ](docs/faq.md), [API guide](docs/api.md) and [Config file guide](docs/config_file.md).
+To learn more, read below, or see the [FAQ](docs/faq.md), [API guide](docs/api.md), [How-to guide](docs/howto.md) and [Config file guide](docs/config_file.md).
 
 ### Architecture diagram
 ![Architecture diagram](docs/assets/arch.png "Architecture diagram")

--- a/brave/helpers.py
+++ b/brave/helpers.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import gi
+import sys
+import traceback
 gi.require_version('Gst', '1.0')
 from gi.repository import Gst, GLib
 
@@ -124,7 +126,8 @@ def run_on_master_thread_when_idle(func, **func_args):
             func_args = args['func_args']
             f(**func_args)
         except Exception as e:
-            print('------------ UNCAUGHT EXCEPTION ON MASTER THREAD: %s ------------' % e)
+            print('------------ UNCAUGHT EXCEPTION ON MASTER THREAD: %s ------------' % e, file=sys.stderr)
+            print(traceback.format_exc(), file=sys.stderr)
 
         return False
 

--- a/brave/inputoutputoverlay.py
+++ b/brave/inputoutputoverlay.py
@@ -172,12 +172,13 @@ class InputOutputOverlay():
         if not self.set_pipeline_state(Gst.State.NULL):
             self.logger.warning('Unable to set private pipe to NULL before attempting to delete')
 
-        def remove_element(element):
-            self.pipeline.remove(element)
+        if hasattr(self, 'pipeline'):
+            def remove_element(element):
+                self.pipeline.remove(element)
 
-        iterator = self.pipeline.iterate_elements()
-        iterator.foreach(remove_element)
-        del self.pipeline
+            iterator = self.pipeline.iterate_elements()
+            iterator.foreach(remove_element)
+            del self.pipeline
         self.collection.pop(self.id)
         self.session().report_deleted_item(self)
 
@@ -333,7 +334,8 @@ class InputOutputOverlay():
                         else:
                             self.logger.warning(f'Do not know of type "{prop_details["type"]}"')
                     except ValueError:
-                        self.logger.warning(f'Updated property "{str(value)}" is not a valid {type}, ignoring')
+                        self.logger.warning('Updated property "%s" is not of type "%s", ignoring'
+                                            % (value, prop_details['type']))
 
                 if 'permitted_values' in prop_details:
                     if value not in prop_details['permitted_values']:

--- a/brave/inputoutputoverlay.py
+++ b/brave/inputoutputoverlay.py
@@ -273,6 +273,8 @@ class InputOutputOverlay():
         Called by the constructor to set up any default props.
         '''
         for key, details in self.permitted_props().items():
+            if 'required' in details and details['required'] and not hasattr(self, key):
+                raise brave.exceptions.InvalidConfiguration('"%s" property is required' % key)
             if 'default' in details and not hasattr(self, key):
                 setattr(self, key, details['default'])
 
@@ -305,6 +307,8 @@ class InputOutputOverlay():
             if value is None:
                 if 'permitted_values' in prop_details and None not in prop_details['permitted_values']:
                     raise brave.exceptions.InvalidConfiguration('Cannot set "%s" property to null' % key)
+                if 'required' in prop_details and not prop_details['required']:
+                    raise brave.exceptions.InvalidConfiguration('"%s" is a required property, cannot be null' % key)
                 if hasattr(self, key):
                     delattr(self, key)
                     if key in self.permitted_props():

--- a/brave/inputs/__init__.py
+++ b/brave/inputs/__init__.py
@@ -4,6 +4,7 @@ from brave.inputs.test_audio import TestAudioInput
 from brave.inputs.image import ImageInput
 from brave.inputs.html import HTMLInput
 from brave.inputs.decklink import DecklinkInput
+from brave.inputs.tcp_client import TcpClientInput
 from brave.abstract_collection import AbstractCollection
 import brave.exceptions
 
@@ -27,6 +28,8 @@ class InputCollection(AbstractCollection):
             input = HTMLInput(**args, collection=self)
         elif args['type'] == 'decklink':
             input = DecklinkInput(**args, collection=self)
+        elif args['type'] == 'tcp_client':
+            input = TcpClientInput(**args, collection=self)
         else:
             raise brave.exceptions.InvalidConfiguration(f"Invalid input type '{str(args['type'])}'")
 

--- a/brave/inputs/decklink.py
+++ b/brave/inputs/decklink.py
@@ -51,7 +51,7 @@ class DecklinkInput(Input):
                                         ' device-number=' + str(self.device) +
                                         ' connection=' + str(self.connection) +
                                         ' mode=' + str(self.mode) +
-                                        ' ! videoconvert'
+                                        ' ! videoconvert ! '
                                         + self.default_video_pipeline_string_end() +
                                         ' decklinkaudiosrc device-number=' + str(self.device) + ' connection=1 ! audioconvert'
                                         + self.default_audio_pipeline_string_end()):

--- a/brave/inputs/html.py
+++ b/brave/inputs/html.py
@@ -46,7 +46,7 @@ class HTMLInput(Input):
 
         self.create_pipeline_from_string('cef url="' + self.uri + '" ! '
                                          ' videoconvert ! video/x-raw,format=ARGB ! '
-                                         'queue' + self.default_video_pipeline_string_end())
+                                         'queue ! ' + self.default_video_pipeline_string_end())
 
         self.intervideosink = self.pipeline.get_by_name('intervideosink')
         self.final_video_tee = self.pipeline.get_by_name('final_video_tee')

--- a/brave/inputs/image.py
+++ b/brave/inputs/image.py
@@ -43,7 +43,7 @@ class ImageInput(Input):
 
         # To crop (not resize): videobox autocrop=true border-alpha=0
         pipeline_string = ('uridecodebin name=uridecodebin uri="' + self.uri +
-                           '" ! imagefreeze ! videoconvert ! video/x-raw,pixel-aspect-ratio=1/1,framerate=30/1' +
+                           '" ! imagefreeze ! videoconvert ! video/x-raw,pixel-aspect-ratio=1/1,framerate=30/1 ! ' +
                            self.default_video_pipeline_string_end())
         self.create_pipeline_from_string(pipeline_string)
         self.final_video_tee = self.pipeline.get_by_name('final_video_tee')

--- a/brave/inputs/input.py
+++ b/brave/inputs/input.py
@@ -109,7 +109,7 @@ class Input(InputOutputOverlay):
     def default_video_pipeline_string_end(self):
         # A tee is used so that we can connect this input to multiple mixers/outputs
         # The fakesink with sync=true ensures the stream acts as a live stream even with no connections.
-        return (' ! queue name=video_output_queue ! tee name=final_video_tee allow-not-linked=true '
+        return ('queue name=video_output_queue ! tee name=final_video_tee allow-not-linked=true '
                 'final_video_tee. ! queue ! fakesink sync=true')
 
     def default_audio_pipeline_string_end(self):

--- a/brave/inputs/input.py
+++ b/brave/inputs/input.py
@@ -33,7 +33,9 @@ class Input(InputOutputOverlay):
 
         if not for_config_file:
             if hasattr(self, 'pipeline'):
-                s['position'] = int(str(self.pipeline.query_position(Gst.Format.TIME).cur))
+                position = int(str(self.pipeline.query_position(Gst.Format.TIME).cur))
+                if position is not None and position is not -1:
+                    s['position'] = position
                 s['duration'] = int(str(self.pipeline.query_duration(Gst.Format.TIME).duration))
 
                 has_connection_speed, _, _ = self.pipeline.lookup('connection-speed')
@@ -80,8 +82,6 @@ class Input(InputOutputOverlay):
         caps_string = 'video/x-raw,pixel-aspect-ratio=1/1,format=RGBA'
         if width and height:
             caps_string += ',width=%d,height=%d' % (width, height)
-
-        self.logger.debug('caps_string=%s' % caps_string)
         return caps_string
 
     def _update_video_filter_caps(self):

--- a/brave/inputs/tcp_client.py
+++ b/brave/inputs/tcp_client.py
@@ -70,9 +70,6 @@ class TcpClientInput(Input):
                                 'decodebin name=video_decodebin ')
             # This then can be connected to the common bit of the pipeline:
             pipeline_string += self.default_video_pipeline_string_end()
-        else:
-            # If we don't want the video, dump it:
-            pipeline_string += 'fakesink'
 
         if self.has_audio():
             # The audio part also needs a decodebin:

--- a/brave/inputs/tcp_client.py
+++ b/brave/inputs/tcp_client.py
@@ -1,0 +1,166 @@
+from brave.inputs.input import Input
+from gi.repository import Gst
+import brave.config as config
+import brave.exceptions
+
+
+class TcpClientInput(Input):
+    '''
+    Allows an an input by receiving from another server via TCP.
+    Basically using the `tcpclientsrc` element.
+    '''
+
+    def permitted_props(self):
+        return {
+            **super().permitted_props(),
+            'host': {
+                'type': 'str',
+                'required': True
+            },
+            'port': {
+                'type': 'int',
+                'required': True
+            },
+            'volume': {
+                'type': 'float',
+                'default': 0.8
+            },
+            'width': {
+                'type': 'int'
+            },
+            'height': {
+                'type': 'int'
+            },
+            'xpos': {
+                'type': 'int',
+                'default': 0
+            },
+            'ypos': {
+                'type': 'int',
+                'default': 0
+            },
+            'zorder': {
+                'type': 'int',
+                'default': 1
+            },
+            'container': {
+                'type': 'str',
+                'default': 'mpeg',
+                'permitted_values': {
+                    'mpeg': 'MPEG',
+                    'ogg': 'OGG'
+                }
+            }
+        }
+
+    def create_elements(self):
+        '''
+        Creates the pipeline with elements needed to accept a TCP connection.
+        '''
+
+        # We support ogg and mpeg containers; the right demuxer must be used:
+        demux_element = 'oggdemux' if self.container == 'ogg' else 'tsdemux'
+
+        # We start with tcpclientsrc, and immediately demux it into audio and video.
+        pipeline_string = 'tcpclientsrc name=tcpclientsrc ! %s name=demux ' % demux_element
+
+        if self.has_video():
+            # We need to decode the video:
+            pipeline_string += (' queue2 max-size-time=3000000000 name=demux_to_video_queue ! '
+                                'decodebin name=video_decodebin ')
+            # This then can be connected to the common bit of the pipeline:
+            pipeline_string += self.default_video_pipeline_string_end()
+        else:
+            # If we don't want the video, dump it:
+            pipeline_string += 'fakesink'
+
+        if self.has_audio():
+            # The audio part also needs a decodebin:
+            pipeline_string += (' queue2 max-size-time=3000000000 name=demux_to_audio_queue'
+                                ' ! decodebin name=audio_decodebin')
+
+            # We will then connect this decodebin to aan audio convert/resample
+            pipeline_string += ' audioconvert name=audioconvert ! audioresample ! ' + \
+                config.default_audio_caps() + \
+                self.default_audio_pipeline_string_end()
+
+        self.create_pipeline_from_string(pipeline_string)
+        tcpclientsrc = self.pipeline.get_by_name('tcpclientsrc')
+        tcpclientsrc.set_property('host', self.host)
+        tcpclientsrc.set_property('port', self.port)
+
+        if self.has_video():
+            self.final_video_tee = self.pipeline.get_by_name('final_video_tee')
+            self.demux_to_video_queue = self.pipeline.get_by_name('demux_to_video_queue')
+            self.video_element_after_demux = self.pipeline.get_by_name('video_output_queue')
+            video_decodebin = self.pipeline.get_by_name('video_decodebin')
+            video_decodebin.connect('pad-added', self._on_decodebin_pad_added)
+
+        if self.has_audio():
+            self.final_audio_tee = self.pipeline.get_by_name('final_audio_tee')
+            self.demux_to_audio_queue = self.pipeline.get_by_name('demux_to_audio_queue')
+            self.audio_element_after_demux = self.pipeline.get_by_name('audioconvert')
+            audio_decodebin = self.pipeline.get_by_name('audio_decodebin')
+            audio_decodebin.connect('pad-added', self._on_decodebin_pad_added)
+
+        demux = self.pipeline.get_by_name('demux')
+        demux.connect('pad-added', self._on_demux_pad_added)
+
+    def _on_demux_pad_added(self, _, pad):
+        '''
+        Demux creates new pads every time the stream starts.
+        This handles the creation of a new pad by linking it to the relevant element.
+        The pipeline is:
+        - For video: demuxer --> demux_to_video_queue --> decodebin --> ...
+        - For audio: demuxer --> demux_to_audio_queue --> decodebin --> ...
+        '''
+        if not pad.has_current_caps():
+            return
+
+        caps = pad.get_current_caps()
+        structure = caps.get_structure(0)
+        name = structure.get_name()
+        element_to_connect_to = None
+        if name.startswith('video'):
+            if hasattr(self, 'demux_to_video_queue'):
+                element_to_connect_to = self.demux_to_video_queue
+
+        elif name.startswith('audio'):
+            if hasattr(self, 'demux_to_audio_queue'):
+                element_to_connect_to = self.demux_to_audio_queue
+
+        else:
+            raise brave.exceptions.PipelineFailure('TCP Client: Unexpected pad name %s' % name)
+
+        if not element_to_connect_to:
+            return
+
+        pad_to_connect_to = element_to_connect_to.get_static_pad('sink')
+        if pad.link(pad_to_connect_to) is not Gst.PadLinkReturn.OK:
+            self.logger.warning('Unable to connect demuxer to queue')
+
+    def _on_decodebin_pad_added(self, _, pad):
+        '''
+        Like demux, decodebin creates new pads every time the stream starts.
+        This handles the creation of a new pad by linking it to the relevant element.
+        The pipeline is:
+        - For video: decodebin --> video_output_queue --> tee --> ...
+        - For audio: decodebin --> audioconvert --> audioresample --> ...
+        '''
+        if not pad.has_current_caps():
+            return
+
+        caps = pad.get_current_caps()
+        structure = caps.get_structure(0)
+        name = structure.get_name()
+        element_to_connect_to = None
+        if name.startswith('video'):
+            element_to_connect_to = self.video_element_after_demux
+        elif name.startswith('audio'):
+            element_to_connect_to = self.audio_element_after_demux
+        else:
+            raise brave.exceptions.PipelineFailure('TCP Client: Unexpected decodebin pad name %s' % name)
+
+        pad_to_connect_to = element_to_connect_to.get_static_pad('sink')
+        if pad.link(pad_to_connect_to) is not Gst.PadLinkReturn.OK:
+            self.logger.warning('Unable to connect demuxer to queue')

--- a/brave/inputs/test_video.py
+++ b/brave/inputs/test_video.py
@@ -36,7 +36,7 @@ class TestVideoInput(Input):
 
     def create_elements(self):
         pipeline_string = ('videotestsrc is-live=true name=videotestsrc'
-                           ' ! videoconvert ! videoscale ! capsfilter name=capsfilter' +
+                           ' ! videoconvert ! videoscale ! capsfilter name=capsfilter ! ' +
                            self.default_video_pipeline_string_end())
         # FOR TESTING TO VIEW LOCALLY, APPEND: + ' final_video_tee. ! queue ! glimagesink ')
         self.create_pipeline_from_string(pipeline_string)

--- a/brave/inputs/uri.py
+++ b/brave/inputs/uri.py
@@ -80,7 +80,7 @@ class UriInput(Input):
 
     def create_video_elements(self):
         bin_as_string = ('videoconvert ! videoscale ! capsfilter name=capsfilter ! '
-                         'queue' + self.default_video_pipeline_string_end())
+                         'queue ! ' + self.default_video_pipeline_string_end())
         bin = Gst.parse_bin_from_description(bin_as_string, True)
 
         self.capsfilter = bin.get_by_name('capsfilter')

--- a/brave/mixers/mixer.py
+++ b/brave/mixers/mixer.py
@@ -77,6 +77,9 @@ class Mixer(InputOutputOverlay):
             if not isinstance(self.sources, list):
                 raise brave.exceptions.InvalidConfiguration('%s "sources" property not a list' % self.uid)
             for details in self.sources:
+                if not isinstance(details, dict):
+                    raise brave.exceptions.InvalidConfiguration('%s "sources" property contains an entry that '
+                                                                'is not a dictionary: %s' % (self.uid, details))
                 if not details['uid']:
                     raise brave.exceptions.InvalidConfiguration('%s "sources" property missing a uid' % self.uid)
                 source_block = self.session().uid_to_block(details['uid'])

--- a/brave/outputs/kvs.py
+++ b/brave/outputs/kvs.py
@@ -47,4 +47,4 @@ class KvsOutput(Output):
         kvssink.set_property('stream-name', self.stream_name)
 
     def create_caps_string(self):
-        return super().create_caps_string(format='I420') + ',pixel-aspect-ratio=1/1,framerate=30/1'
+        return super().create_caps_string(format='I420') + ',framerate=30/1'

--- a/brave/outputs/local.py
+++ b/brave/outputs/local.py
@@ -40,4 +40,4 @@ class LocalOutput(Output):
 
     def create_caps_string(self):
         # format=RGB removes the alpha channel which can crash glimagesink
-        return super().create_caps_string(format='RGB') + ',pixel-aspect-ratio=1/1'
+        return super().create_caps_string(format='RGB')

--- a/brave/outputs/output.py
+++ b/brave/outputs/output.py
@@ -97,7 +97,7 @@ class Output(InputOutputOverlay):
         Returns the preferred caps (a string defining things such as width, height and framerate)
         '''
 
-        caps = 'video/x-raw,format=%s' % format
+        caps = 'video/x-raw,format=%s,pixel-aspect-ratio=1/1' % format
 
         # If only one dimension is provided, we calculate the other.
         # Some encoders (jpegenc, possibly others) don't like it if only one metric is present.
@@ -160,8 +160,11 @@ class Output(InputOutputOverlay):
         The standard start to the pipeline string for video.
         It starts with intervideosrc, which accepts video from the source.
         '''
-        return ('intervideosrc name=intervideosrc ! videoconvert ! videoscale ! '
-                'videorate ! capsfilter name=capsfilter ! ')
+        # The large timeout holds any stuck frame for 24 hours (basically, a very long time)
+        # This is optional, but prevents it from going black when it's better to show the last frame.
+        timeout = Gst.SECOND * 60 * 60 * 24
+        return ('intervideosrc name=intervideosrc timeout=%d ! videoconvert ! videoscale ! '
+                'videorate ! capsfilter name=capsfilter ! ' % timeout)
 
     def _audio_pipeline_start(self):
         '''

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,6 +19,9 @@ Because Brave is based on GStreamer, it can only support what GStreamer supports
 
 Where GStreamer plugins do exist, adding them as a new form of input or output should be relatively easy. Start with an existing one (in the `brave/inputs` and `brave/outputs` directories) and clone it. Then please raise as a pull request. Or you could [request it by raising an issue](https://github.com/bbc/brave/issues).
 
+## How do I... ?
+See the [How-To](howto.md) page.
+
 ## I've found a bug
 Please [raise an issue in GitHub](https://github.com/bbc/brave/issues).
 

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -1,9 +1,57 @@
 # Brave How-To Guide
-This is a how-to guide for common use-cases of [Brave](../README.md).
+This is a how-to guide for some common use-cases of [Brave](../README.md).
 See also the [FAQ](faq.md), as well as documentation on the [config file](config_file.md) and [API](api.md).
 
+## How to use Brave as an audio mixer
+Brave can be set to handle just audio, and no video. To do so, create a config file containing `enable_video: false`. Then start Brave providing it, for example:
+
+```
+echo 'enable_video: false' > /tmp/no_video.yaml
+./brave.py -c /tmp/no_video.yaml
+```
+
+Here is a richer config file example, setting audio-only and two MP3 inputs:
+
+```
+enable_video: false
+
+inputs:
+  - type: uri
+    uri: "file:///path/to/music1.mp3"
+    loop: true
+  - type: uri
+    uri: "file:///path/to/music2.mp3"
+    loop: true
+
+mixers:
+  - sources:
+    - uid: input1
+
+outputs:
+  - type: local
+    source: mixer1
+```
+
+The mixer has the first input as its source. To switch to the other source, use either the web interface, or the API, e.g.
+
+```
+# Switch to input 2:
+curl -X POST -d '{"source": "input2"}' http://localhost:5000/api/mixers/1/cut_to_source
+```
+
+Mixing two inputs together can be done with `overlay_source` rather than `cut_to_source`.
+
+Seeking to a certain position in (non-live) audio can be done with the `position` property. Multiply the number of seconds position by 1000000000. For example, this will seek to 60 seconds:
+
+```
+# Move input 1 to 60 seconds:
+curl -X POST -d '{"position": 60000000000}' http://localhost:5000/inputs/1
+```
+
+Adding and removing inputs can also be done via the web interface or API.
+
 ## How to connect a separate GStreamer pipeline to Brave
-The best method to output a video (either with or without audio) to Brave is using the TCP protocol. Use the [`tcpserversink`](https://developer.gnome.org/gst-plugins-libs/stable/gst-plugins-base-plugins-tcpserversink.html) element to act as  TCP server; which Brave can then connect to.
+The best method to output a video (either with or without audio) from GStreamer to Brave is using the TCP protocol. Use the [`tcpserversink`](https://developer.gnome.org/gst-plugins-libs/stable/gst-plugins-base-plugins-tcpserversink.html) element to act as  TCP server; which Brave can then connect to.
 
 The GStreamer process can be running on the same server as Brave, or a different one that has good network connectivity.
 
@@ -26,7 +74,7 @@ curl -X PUT -d '{"type": "tcp_client", "host": "0.0.0.0", "port":13001}' http://
 
 Not that this input type assumes the content is delivered as an *MPEG* container. Support for an *Ogg* container is also possible by setting the parameter `container` to `ogg`.
 
-## How to output Brave to a separate GStreamer pipeline.
+## How to output Brave to a separate GStreamer pipeline
 Like above, a TCP connection works well for this, both on the same box and on remote boxes (with good network connections).
 
 First, create a `TCP` output in Brave. This creates a TCP Server from which other GStreamers can connect as clients. You can do this in the config file, or GUI, or as an API call on the command line like this:

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -1,0 +1,44 @@
+# Brave How-To Guide
+This is a how-to guide for common use-cases of [Brave](../README.md).
+See also the [FAQ](faq.md), as well as documentation on the [config file](config_file.md) and [API](api.md).
+
+## How to connect a separate GStreamer pipeline to Brave
+The best method to output a video (either with or without audio) to Brave is using the TCP protocol. Use the [`tcpserversink`](https://developer.gnome.org/gst-plugins-libs/stable/gst-plugins-base-plugins-tcpserversink.html) element to act as  TCP server; which Brave can then connect to.
+
+The GStreamer process can be running on the same server as Brave, or a different one that has good network connectivity.
+
+Here is an example (a moving ball image and an audio test sound):
+
+```
+gst-launch-1.0   \
+    videotestsrc pattern=ball ! video/x-raw,width=640,height=360 ! \
+    x264enc ! muxer. \
+    audiotestsrc ! avenc_ac3 ! muxer. \
+    mpegtsmux name=muxer ! queue ! \
+    tcpserversink host=0.0.0.0 port=13000 recover-policy=keyframe sync-method=latest-keyframe sync=false
+```
+
+To connect Brave to this, create an input of type `tcp_client`. This can be done in the start-up config file, or by REST API, or by the web client. For example, to create an input using the REST API, as a Curl command:
+
+```
+curl -X PUT -d '{"type": "tcp_client", "host": "0.0.0.0", "port":13001}' http://localhost:5000/api/inputs
+```
+
+Not that this input type assumes the content is delivered as an *MPEG* container. Support for an *Ogg* container is also possible by setting the parameter `container` to `ogg`.
+
+## How to output Brave to a separate GStreamer pipeline.
+Like above, a TCP connection works well for this, both on the same box and on remote boxes (with good network connections).
+
+First, create a `TCP` output in Brave. This creates a TCP Server from which other GStreamers can connect as clients. You can do this in the config file, or GUI, or as an API call on the command line like this:
+
+```
+curl -X PUT -d '{"type": "tcp", "source": "mixer1", "port": 13000}' http://localhost:5000/api/outputs
+```
+
+Then, create a GStreamer pipeline that listens to that port. For example, this one will play it locally (audio & video):
+
+```
+gst-launch-1.0 tcpclientsrc host=0.0.0.0 port=13000 ! tsdemux name=demux  ! queue2 max-size-time=3000000000 ! decodebin ! autovideosink demux. ! queue2 max-size-time=3000000000 ! decodebin ! autoaudiosink
+```
+
+(The large `max-size-time` values help accomodate the key-frame interval.)

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -21,6 +21,7 @@ Brave currently supports these input types:
 
 - [uri](#uri)
 - [image](#image)
+- [TCP Client](#TCP_client)
 - [test_video](#test_video)
 - [test_audio](#test_audio)
 
@@ -51,7 +52,7 @@ In addition to the common properties above, this input type also has the followi
 | `position` | No (should be possible in a future release) | Yes | The current position (time) of the media. It's in nanoseconds (so divide the number by 1000000000 to turn into seconds). | 0 |
 | `duration` | No | Yes | The duration of the content, or `-1` if there is no duration (e.g. for a live stream). | The asset duration, or `-1` |
 | `buffer_duration` | Yes | Yes | The size of the buffer, in nanoseconds (so divide the number by 1000000000 to turn into seconds). | 2 seconds (GStreamer default) |
-| `loop` | Yes | Yes | Should the content loop when it reaches the end? Either `true` or `false`. | `false` |
+| `loop` | Yes | Yes | Should the content loop when it reaches the end? Either `true` or `false`. (Note this does not work as well for looping RTMP inputs, because the input falls back to `decodebin` rather than `decodebin3`.) | `false` |
 
 ### image
 The `image` input type is for when an image (JPEG, PNG, etc.) should be displayed on the video. This can be used as a way of adding graphics. PNG images with transparent backgrounds are supported (and work well when overlayed on video). Animated GIFs are not supported.
@@ -65,6 +66,18 @@ In addition to the common properties above, this input type also has the followi
 | ---- | --------------------- | ---------------- | ----------- | -------------------------- |
 | `uri` | Yes | No | The URI of the image | n/a - REQUIRED PROPERTY |
 | `width` and `height` | Yes | Yes | Override of the width and height | None (will appear full-screen on mixer/output) |
+
+### TCP Client
+The `tcp_client` input type can retrieve content from a TCP server, created using GStreamer's [`tcpserversink`](https://developer.gnome.org/gst-plugins-libs/stable/gst-plugins-base-plugins-tcpserversink.html) element. For more description on how to use this, see the [how-to](howto.md) guide.
+
+#### Properties
+In addition to the common properties above, this input type also has the following:
+
+| Name | Can be set initially? | Can be updated?? | Description | Default value (if not set) |
+| ---- | --------------------- | ---------------- | ----------- | -------------------------- |
+| `host` | Yes | No | The hostname of the TCP server to connect to | `0.0.0.0` (i.e. the current server) |
+| `port` | Yes | No | The port of the TCP server to connect to | n/a - REQUIRED PROPERTY |
+| `container` | Yes | No | Whether to expect `mpeg` or `ogg` as the content container. | `mpeg` |
 
 ### test_video
 A video test source, which is useful for checking connections, or to provide a background. There is no audio.

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -49,7 +49,7 @@ In addition to the common properties above, this input type also has the followi
 | `uri` | Yes | No | The URI of the image | n/a - REQUIRED PROPERTY |
 | `width` and `height` | Yes | Yes | Override of the width and height (both non-negative integers) | None (will appear full-screen on mixer/output) |
 | `volume` | Yes | Yes | The volume. Floating point value, between 0 (silent) and 1 (full volume). | 0.8 |
-| `position` | No (should be possible in a future release) | Yes | The current position (time) of the media. It's in nanoseconds (so divide the number by 1000000000 to turn into seconds). | 0 |
+| `position` | Yes | Yes | The current position (time) of the media. It's in nanoseconds (so divide the number by 1000000000 to turn into seconds). | 0 |
 | `duration` | No | Yes | The duration of the content, or `-1` if there is no duration (e.g. for a live stream). | The asset duration, or `-1` |
 | `buffer_duration` | Yes | Yes | The size of the buffer, in nanoseconds (so divide the number by 1000000000 to turn into seconds). | 2 seconds (GStreamer default) |
 | `loop` | Yes | Yes | Should the content loop when it reaches the end? Either `true` or `false`. (Note this does not work as well for looping RTMP inputs, because the input falls back to `decodebin` rather than `decodebin3`.) | `false` |

--- a/public/js/components.js
+++ b/public/js/components.js
@@ -98,7 +98,7 @@ components.stateBox = (item, onClick) => {
 
 components._stateIcons = (item) => {
     let desc = ' ' + item.state
-    if (item.hasOwnProperty('buffering_percent') && item.buffering_percent !== 100) {
+    if (item.state == 'PAUSED' && item.hasOwnProperty('buffering_percent') && item.buffering_percent !== 100) {
         desc = ' BUFFERING (' + item.buffering_percent + '%)'
     }
     else if (item.desired_state && item.desired_state !== item.state) {

--- a/public/js/inputs.js
+++ b/public/js/inputs.js
@@ -72,6 +72,9 @@ inputsHandler._inputCardBody = (input) => {
     if (input.hasOwnProperty('device')) details.push('<div><strong>Device Num:</strong> ' + input.device + '</div>')
     if (input.hasOwnProperty('connection')) details.push('<div><strong>Connection Type:</strong> ' + inputsHandler.decklinkConnection[input.connection] + '</div>')
     if (input.hasOwnProperty('mode')) details.push('<div><strong>Input Mode:</strong> ' + inputsHandler.decklinkModes[input.mode] + '</div>')
+    if (input.hasOwnProperty('host')) details.push('<div><strong>Host:</strong> ' + input.host + '</div>')
+    if (input.hasOwnProperty('port')) details.push('<div><strong>Port:</strong> ' + input.port + '</div>')
+    if (input.hasOwnProperty('container')) details.push('<div><strong>Container:</strong> ' + input.container + '</div>')
 
     if (input.hasOwnProperty('duration')) {
         var duration = prettyDuration(input.duration)
@@ -144,6 +147,30 @@ inputsHandler._populateForm = function(input) {
         name: 'zorder',
         type: 'number',
         value: input.zorder || inputsHandler.getNextZorder()
+    })
+
+    const hostBox = formGroup({
+        id: 'input-host',
+        label: 'Hostname',
+        name: 'host',
+        type: 'text',
+        value: input.host
+    })
+
+    const portBox = formGroup({
+        id: 'input-port',
+        label: 'Port',
+        name: 'port',
+        type: 'number',
+        value: input.port
+    })
+
+    const containerBox = formGroup({
+        id: 'input-container',
+        label: 'Container',
+        name: 'container',
+        options: {mpeg: 'MPEG', ogg: 'OGG'},
+        value: (input.container || 'mpeg')
     })
 
     var uriRow = formGroup({
@@ -219,6 +246,7 @@ inputsHandler._populateForm = function(input) {
         var options = {
             'uri': 'URI (for files, RTMP, RTSP and HLS)',
             'image': 'Image',
+            'tcp_client': 'TCP Client (receive from a TCP server)',
             'html': 'HTML (for showing a web page)',
             'decklink': 'Decklink Device',
             'test_video': 'Test video stream',
@@ -280,6 +308,12 @@ inputsHandler._populateForm = function(input) {
         form.append(sizeBox);
         form.append(zOrderBox);
     }
+    else if (input.type === 'tcp_client') {
+        if (isNew) form.append(hostBox)
+        if (isNew) form.append(portBox)
+        if (isNew) form.append(containerBox)
+        form.append(components.volumeInput(input.volume))
+    }
     form.find('select[name="type"]').change(inputsHandler._handleNewFormType);
 }
 
@@ -291,7 +325,7 @@ inputsHandler._handleFormSubmit = function() {
     const input = isNew ? {} : inputsHandler.findById(id)
     const newProps = {}
 
-    fields = ['type', 'uri', 'position', 'zorder', 'dimensions', 'freq', 'volume', 'input_volume', 'pattern', 'wave', 'buffer_duration']
+    fields = ['type', 'uri', 'position', 'zorder', 'dimensions', 'freq', 'volume', 'input_volume', 'pattern', 'wave', 'buffer_duration', 'host', 'port', 'container']
     fields.forEach(function(f) {
         var input = form.find('[name="' + f + '"]')
         if (input && input.val() !== null && input.val() !== '') {

--- a/public/js/inputs.js
+++ b/public/js/inputs.js
@@ -154,7 +154,7 @@ inputsHandler._populateForm = function(input) {
         label: 'Hostname',
         name: 'host',
         type: 'text',
-        value: input.host
+        value: input.host || '0.0.0.0'
     })
 
     const portBox = formGroup({

--- a/tests/test_rtmp.py
+++ b/tests/test_rtmp.py
@@ -1,6 +1,7 @@
 import time
 import os
 import utils
+import pytest
 from utils import run_brave, create_config_file
 
 BRAVE_1_PORT = 12345
@@ -99,7 +100,6 @@ def subtest_start_brave_with_rtmp_input(run_brave, create_config_file, rtmp_url)
     config_file = create_config_file(config)
     run_brave(config_file.name, BRAVE_2_PORT)
     utils.check_brave_is_running()
-    # time.sleep(0.5)
 
 
 def is_brave_in_playing_state(port):

--- a/tests/test_rtmp.py
+++ b/tests/test_rtmp.py
@@ -1,0 +1,109 @@
+import time
+import os
+import utils
+from utils import run_brave, create_config_file
+
+BRAVE_1_PORT = 12345
+BRAVE_2_PORT = 12346
+
+
+def test_rtmp(run_brave, create_config_file):
+    '''
+    We test both RTMP as an input and output by sending an RTMP stream from one Brave to another.
+    An RTMP server is required in the middle, which needs to be provided seprately.
+    Set as the RTMP_SERVER env variable, e.g.
+    export RTMP_SERVER="myserver.com:10000"
+    '''
+    if 'RTMP_SERVER' not in os.environ:
+        pytest.skip('RMTP_SERVER environment variable not set')
+        return
+
+    rtmp_url = 'rtmp://' + os.environ['RTMP_SERVER'] + '/live/test1'
+
+    subtest_start_brave_with_rtmp_output(run_brave, create_config_file, rtmp_url)
+    subtest_start_brave_with_rtmp_input(run_brave, create_config_file, rtmp_url)
+
+    attempts_remaining = 20
+    everthing_in_playing_state = False
+    while attempts_remaining > 0:
+        attempts_remaining -= 1
+        time.sleep(1)
+        everything_in_playing_state = is_brave_in_playing_state(BRAVE_1_PORT) and is_brave_in_playing_state(BRAVE_2_PORT)
+
+    assert everything_in_playing_state, 'Cannot get everything into PLAYING state'
+
+    # Becaue Brave 1 is showing all red, and Brave 2 is receiving Brave 1 via RTMP,
+    # Then the output of Brave 2 should be all Red
+    print('NOW RED')
+    time.sleep(20)
+    utils.assert_image_output_color(1, [255, 0, 0], port=BRAVE_2_PORT)
+
+    # Now make first Brave all blue
+    utils.update_input(1, {'pattern': 6}, port=BRAVE_1_PORT)  # Pattern 6 is blue
+
+    # Second brave will now be blue, if TCP connection is working
+    print('NOW BLUE')
+    time.sleep(20) # Takes an annoyingly long time to buffer....
+    utils.assert_image_output_color(1, [0, 0, 255], port=BRAVE_2_PORT)
+
+
+def subtest_start_brave_with_rtmp_output(run_brave, create_config_file, rtmp_url):
+    config = {
+        'inputs': [
+            {
+                'type': 'test_video',
+                'pattern': 4,  # RED
+            }
+        ],
+        'outputs': [
+            {
+                'type': 'rtmp',
+                'source': 'input1',
+                'uri': rtmp_url
+            }
+        ]
+    }
+    config_file = create_config_file(config)
+    run_brave(config_file.name, BRAVE_1_PORT)
+    utils.check_brave_is_running()
+    # time.sleep(0.5)
+
+
+def subtest_start_brave_with_rtmp_input(run_brave, create_config_file, rtmp_url):
+    config = {
+        'inputs': [
+            {
+                'type': 'uri',
+                'uri': rtmp_url
+            }
+        ],
+        # 'mixers': [
+        #     {
+        #         'sources': [
+        #             {'uid': 'input1'}
+        #         ]
+        #     }
+        # ],
+        'outputs': [
+            {
+                'type': 'image',
+                'source': 'input1'
+            # ADD A PREVIEW, for debugging:
+            },
+            {
+                'type': 'local',
+                'source': 'input1'
+            }
+        ]
+    }
+    config_file = create_config_file(config)
+    run_brave(config_file.name, BRAVE_2_PORT)
+    utils.check_brave_is_running()
+    # time.sleep(0.5)
+
+
+def is_brave_in_playing_state(port):
+    response = utils.api_get('/api/all', port=port)
+    assert response.status_code == 200
+    response_json = response.json()
+    return response_json['inputs'][0]['state'] == 'PLAYING' and response_json['outputs'][0]['state'] == 'PLAYING'

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -12,56 +12,77 @@ TCP_PORT = 13100
 
 
 def test_tcp_with_mpeg_container(run_brave, create_config_file):
-    _test_tcp(run_brave, create_config_file, 'mpeg')
+    _test_tcp(run_brave, create_config_file, 'mpeg', {'enable_video': True, 'enable_audio': True})
+
+
+def test_tcp_with_mpeg_container_video_only(run_brave, create_config_file):
+    _test_tcp(run_brave, create_config_file, 'mpeg', {'enable_video': True, 'enable_audio': False})
+
+
+def test_tcp_with_mpeg_container_audio_only(run_brave, create_config_file):
+    _test_tcp(run_brave, create_config_file, 'mpeg', {'enable_video': False, 'enable_audio': True})
 
 
 def test_tcp_with_ogg_container(run_brave, create_config_file):
-    _test_tcp(run_brave, create_config_file, 'ogg')
+    _test_tcp(run_brave, create_config_file, 'ogg', {'enable_video': True, 'enable_audio': True})
 
 
-def _test_tcp(run_brave, create_config_file, container):
-    subtest_start_brave_with_tcp_output(run_brave, create_config_file, container)
-    subtest_start_brave_with_tcp_input(run_brave, create_config_file, container)
-    time.sleep(3)
-    subtest_ensure_first_brave_content_appears_in_second()
+# Could test OGG with just video/audio but there's probably no need.
+
+def _test_tcp(run_brave, create_config_file, container, config):
+    subtest_start_brave_with_tcp_output(run_brave, create_config_file, container, {**config})
+    subtest_start_brave_with_tcp_input(run_brave, create_config_file, container, {**config})
+
+    if config['enable_video']:
+        time.sleep(3)
+        subtest_ensure_first_brave_content_appears_in_second()
 
 
-def subtest_start_brave_with_tcp_output(run_brave, create_config_file, container):
-    config = {
-        'inputs': [
+def subtest_start_brave_with_tcp_output(run_brave, create_config_file, container, config):
+
+    if config['enable_video']:
+        config['inputs'] = [
             {
                 'type': 'test_video',
                 'pattern': 4,  # RED
             }
-        ],
-        'outputs': [
+        ]
+    else:
+        config['inputs'] = [
             {
-                'type': 'tcp',
-                'container': container,
-                'source': 'input1',
-                'host': TCP_HOST,
-                'port': TCP_PORT
+                'type': 'test_audio'
             }
         ]
-    }
+
+    config['outputs'] = [
+        {
+            'type': 'tcp',
+            'container': container,
+            'source': 'input1',
+            'host': TCP_HOST,
+            'port': TCP_PORT
+        }
+    ]
+
     config_file = create_config_file(config)
     run_brave(config_file.name, BRAVE_1_PORT)
-    time.sleep(0.5)
+    time.sleep(2)
     utils.check_brave_is_running()
     utils.assert_everything_in_playing_state(port=BRAVE_1_PORT)
 
 
-def subtest_start_brave_with_tcp_input(run_brave, create_config_file, container):
-    config = {
-        'inputs': [
-            {
-                'type': 'tcp_client',
-                'container': container,
-                'host': TCP_HOST,
-                'port': TCP_PORT
-            }
-        ],
-        'outputs': [
+def subtest_start_brave_with_tcp_input(run_brave, create_config_file, container, config):
+    config['inputs'] = [
+        {
+            'type': 'tcp_client',
+            'container': container,
+            'host': TCP_HOST,
+            'port': TCP_PORT
+        }
+    ]
+
+    if config['enable_video']:
+        config['outputs'] = [
             {
                 'type': 'image',
                 'source': 'input1'
@@ -72,11 +93,11 @@ def subtest_start_brave_with_tcp_input(run_brave, create_config_file, container)
             #     'source': 'input1'
             # }
         ]
-    }
+
     config_file = create_config_file(config)
     run_brave(config_file.name, BRAVE_2_PORT)
     utils.check_brave_is_running()
-    time.sleep(2)
+    time.sleep(3)
     utils.assert_everything_in_playing_state(port=BRAVE_2_PORT)
 
 

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -1,0 +1,92 @@
+'''
+We test both TCP as an input and output by connecting two Braves together.
+'''
+import time
+import utils
+from utils import run_brave, create_config_file
+
+BRAVE_1_PORT = 12345
+BRAVE_2_PORT = 12346
+TCP_HOST = '0.0.0.0'
+TCP_PORT = 13100
+
+
+def test_tcp_with_mpeg_container(run_brave, create_config_file):
+    _test_tcp(run_brave, create_config_file, 'mpeg')
+
+
+def test_tcp_with_ogg_container(run_brave, create_config_file):
+    _test_tcp(run_brave, create_config_file, 'ogg')
+
+
+def _test_tcp(run_brave, create_config_file, container):
+    subtest_start_brave_with_tcp_output(run_brave, create_config_file, container)
+    subtest_start_brave_with_tcp_input(run_brave, create_config_file, container)
+    time.sleep(3)
+    subtest_ensure_first_brave_content_appears_in_second()
+
+
+def subtest_start_brave_with_tcp_output(run_brave, create_config_file, container):
+    config = {
+        'inputs': [
+            {
+                'type': 'test_video',
+                'pattern': 4,  # RED
+            }
+        ],
+        'outputs': [
+            {
+                'type': 'tcp',
+                'container': container,
+                'source': 'input1',
+                'host': TCP_HOST,
+                'port': TCP_PORT
+            }
+        ]
+    }
+    config_file = create_config_file(config)
+    run_brave(config_file.name, BRAVE_1_PORT)
+    time.sleep(0.5)
+    utils.check_brave_is_running()
+    utils.assert_everything_in_playing_state(port=BRAVE_1_PORT)
+
+
+def subtest_start_brave_with_tcp_input(run_brave, create_config_file, container):
+    config = {
+        'inputs': [
+            {
+                'type': 'tcp_client',
+                'container': container,
+                'host': TCP_HOST,
+                'port': TCP_PORT
+            }
+        ],
+        'outputs': [
+            {
+                'type': 'image',
+                'source': 'input1'
+            },
+            # PREVIEW for debugging:
+            # {
+            #     'type': 'local',
+            #     'source': 'input1'
+            # }
+        ]
+    }
+    config_file = create_config_file(config)
+    run_brave(config_file.name, BRAVE_2_PORT)
+    utils.check_brave_is_running()
+    time.sleep(2)
+    utils.assert_everything_in_playing_state(port=BRAVE_2_PORT)
+
+
+def subtest_ensure_first_brave_content_appears_in_second():
+    # First brave is all red. So second Brave should be red too.
+    utils.assert_image_output_color(1, [255, 0, 0], port=BRAVE_2_PORT)
+
+    # Now make first Brave all green
+    utils.update_input(1, {'pattern': 5}, port=BRAVE_1_PORT)  # Pattern 5 is green
+
+    # Second brave will now be green, if TCP connection is working
+    time.sleep(6)
+    utils.assert_image_output_color(1, [0, 255, 0], port=BRAVE_2_PORT)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,10 @@ def run_brave(config_file=None, port=None):
         brave_processes[config_file] = subprocess.Popen(cmd, shell=True)
         time.sleep(1)
     yield _run_brave
-    print('Stopping Brave...')
+    if port:
+        print('Stopping Brave on port %d...' % port)
+    else:
+        print('Stopping Brave...')
     global brave_processes
     for config_file, process in brave_processes.items():
         process.send_signal(signal.SIGINT)
@@ -28,18 +31,18 @@ def api_get(path, port=DEFAULT_PORT, stream=False):
     return requests.get(url, stream=stream)
 
 
-def api_post(path, data):
-    url = 'http://localhost:%d%s' % (DEFAULT_PORT, path)
+def api_post(path, data, port=DEFAULT_PORT):
+    url = 'http://localhost:%d%s' % (port, path)
     return requests.post(url, data=json.dumps(data))
 
 
-def api_put(path, data):
-    url = 'http://localhost:%d%s' % (DEFAULT_PORT, path)
+def api_put(path, data, port=DEFAULT_PORT):
+    url = 'http://localhost:%d%s' % (port, path)
     return requests.put(url, data=json.dumps(data))
 
 
-def api_delete(path):
-    url = 'http://localhost:%d%s' % (DEFAULT_PORT, path)
+def api_delete(path, port=DEFAULT_PORT):
+    url = 'http://localhost:%d%s' % (port, path)
     return requests.delete(url)
 
 brave_process = None
@@ -253,8 +256,8 @@ def delete_input(id, expected_status_code=200):
     time.sleep(0.2)
 
 
-def update_input(id, updates, expected_status_code=200):
-    response = api_post('/api/inputs/' + str(id), updates)
+def update_input(id, updates, expected_status_code=200, port=DEFAULT_PORT):
+    response = api_post('/api/inputs/' + str(id), updates, port)
     assert response.status_code == expected_status_code
     time.sleep(0.2)
 
@@ -357,11 +360,5 @@ def __assert_image_color(im, expected):
         actual = im.getpixel(dimension)
         p = actual
         for i in range(len(expected)):
-            if not (expected[i]-PERMITTED_RANGE) < actual[i] < (expected[i]+PERMITTED_RANGE):
-                print('OH DEAR')
-                print('%s value was %d but expected %d (within range of %d)' % (NAMES[i], actual[i], expected[i], PERMITTED_RANGE))
-                print('SLEEPING')
-                # time.sleep(100)
-
-            # assert (expected[i]-PERMITTED_RANGE) < actual[i] < (expected[i]+PERMITTED_RANGE), \
-            #     '%s value was %d but expected %d (within range of %d)' % (NAMES[i], actual[i], expected[i], PERMITTED_RANGE)
+            assert (expected[i]-PERMITTED_RANGE) < actual[i] < (expected[i]+PERMITTED_RANGE), \
+                '%s value was %d but expected %d (within range of %d)' % (NAMES[i], actual[i], expected[i], PERMITTED_RANGE)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -97,7 +97,9 @@ def assert_mixers_in_playing_state(json_response):
 
 def assert_everything_in_playing_state(json_response=None, port=DEFAULT_PORT):
     if json_response is None:
-        json_response = api_get('/api/all', port=port)
+        response = api_get('/api/all', port=port)
+        json_response = response.json()
+
     assert_inputs_in_playing_state(json_response)
     assert_outputs_in_playing_state(json_response)
     assert_mixers_in_playing_state(json_response)


### PR DESCRIPTION
- ‘uri’ input can not have its position (seeking) set when created
- New input type ‘TCP Client'
- New TCP test (both input and output)
- New RTMP test (both input and output)
- A few bug fixes found from creating these tests
- New ‘How to’ doc page to show how to use these input types

- [x] Test written
- [x] Code linted
- [x] Docs updated