### PR TITLE
Fix bug with overlays when no source

### DIFF
--- a/brave/overlays/overlay.py
+++ b/brave/overlays/overlay.py
@@ -1,5 +1,6 @@
 from gi.repository import Gst
 from brave.inputoutputoverlay import InputOutputOverlay
+import brave.exceptions
 
 
 class Overlay(InputOutputOverlay):
@@ -39,6 +40,9 @@ class Overlay(InputOutputOverlay):
 
         if 'visible' in updates:
             if not self.visible and updates['visible']:
+                if not self.source:
+                    raise brave.exceptions.InvalidConfiguration(
+                        'Cannot make overlay %d visible - source not set' % self.id)
                 self.logger.debug('Becoming visible')
                 self._make_visible()
             if self.visible and not updates['visible']:

--- a/tests/test_overlays.py
+++ b/tests/test_overlays.py
@@ -26,10 +26,33 @@ def test_overlay_at_start(run_brave, create_config_file):
                      {'id': 2, 'visible': True},
                      {'id': 3, 'visible': True}])
 
+    subtest_delete_overlay()
+    subtest_add_overlay_without_source()
+    subtest_make_overlay_without_source_visible()
+
+
+def subtest_delete_overlay():
     delete_overlay(3)
     time.sleep(1)
     assert_overlays([{'id': 1, 'visible': False},
                      {'id': 2, 'visible': True}])
+
+
+def subtest_add_overlay_without_source():
+    add_overlay({'type': 'text', 'text': 'Overlay #3b', 'visible': False})
+    time.sleep(1)
+    assert_overlays([{'id': 1, 'visible': False, 'source': 'mixer1'},
+                     {'id': 2, 'visible': True, 'source': 'mixer1'},
+                     {'id': 3, 'visible': False, 'source': None}])
+
+
+def subtest_make_overlay_without_source_visible():
+    # Cant't make visible if no source - so will return with a 400
+    update_overlay(3, {'visible': True}, status_code=400)
+    time.sleep(1)
+    assert_overlays([{'id': 1, 'visible': False, 'source': 'mixer1'},
+                     {'id': 2, 'visible': True, 'source': 'mixer1'},
+                     {'id': 3, 'visible': False, 'source': None}])
 
 
 def set_up_overlay_at_start(run_brave, create_config_file):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -171,7 +171,7 @@ def delete_overlay(overlay_id):
 
 def update_overlay(overlay_id, details, status_code=200):
     response = api_post('/api/overlays/' + str(overlay_id), details)
-    assert response.status_code == status_code, 'Expected status code %s but got %s, body was:%s' % (status_code, response.status_code, response.json())
+    assert response.status_code == status_code, 'Expected status code %s but got %s, body was:%s' % (status_code, response.status_code, response.text)
 
 
 def set_mixer_state(mixer_id, state, status_code=200):


### PR DESCRIPTION
Simple fix (plus test) to a bug where an overlay would fail badly if it did not have a source.