### PR TITLE
Fix WebRTC on 1.16

### DIFF
--- a/brave/outputs/webrtc.py
+++ b/brave/outputs/webrtc.py
@@ -157,6 +157,7 @@ class WebRTCOutput(Output):
 
         self.peers[ws]['webrtcbin'] = Gst.ElementFactory.make('webrtcbin')
         self.pipeline.add(self.peers[ws]['webrtcbin'])
+        self.peers[ws]['webrtcbin'].set_property('bundle-policy', 'max-bundle')
         self.peers[ws]['webrtcbin'].add_property_notify_watch(None, True)
         self.peers[ws]['webrtcbin'].set_state(Gst.State.READY)
 


### PR DESCRIPTION
Seems like some browsers require this to be set.
Not sure what has chnaged between 1.14 and 1.16 to not set this. But adding it gets webrtc to work again