### PR TITLE
Add missing pipenv install step in Ubuntu docs 

### DIFF
--- a/docs/install_ubuntu.md
+++ b/docs/install_ubuntu.md
@@ -50,6 +50,7 @@ Simply clone Brave from GitHub, and try running it:
 ```
 git clone https://github.com/bbc/brave.git
 cd brave
+pipenv install
 pipenv run ./brave.py
 ```
 


### PR DESCRIPTION
Think there is a missing step as I had to use pipenv install to get it to install missing packages