### PR TITLE
update Dockerfile to use ubuntu:18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:18.04
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8


### PR DESCRIPTION
Ubuntu 18.10 is no longer supported so the `apt-get` commands fail leaving the Dockerfile unbuildable.

Dropping down to the closest LTS version.

It might be worthwhile updating this to 20.04, but will need an actual maintainer to do that because some of the dependencies no longer exist (eg. `libffi6`).