### PR TITLE
Lock pipenv version to a compatible one with the python version on ubuntu 18.04. Install sanic through pipfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get install -yq \
     build-essential \
     gcc \
-    git \ 
+    git \
     libffi6 libffi-dev \
     gobject-introspection \
     gstreamer1.0-libav \
@@ -17,7 +17,7 @@ RUN apt-get update && \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-ugly \
     gstreamer1.0-tools \
-    gir1.2-gst-plugins-bad-1.0 \ 
+    gir1.2-gst-plugins-bad-1.0 \
     libcairo2-dev \
     libgirepository1.0-dev \
     pkg-config \
@@ -32,7 +32,7 @@ RUN apt-get update && \
 
 RUN git clone --depth 1 https://github.com/bbc/brave.git && \
     cd brave && \
-    pip3 install pipenv sanic && \
+    pip3 install -Iv pipenv==2022.4.8 && \
     pipenv install --ignore-pipfile && \
     mkdir -p /usr/local/share/brave/output_images/
 


### PR DESCRIPTION
This change locks the pipenv version to the last known good version that works with the python shipped on Ubuntu 18.04
Also, removed sanic installation through pip as the requirement is defined through Pipfile.

This makes the docker image workable, but webrtc output is broken due to the Gstremaer version being 1.4. It seems current code requires bundle-policy property for webrtcbin, which is available for Gstreamer > 1.6



